### PR TITLE
feat: add exclude from scans feature

### DIFF
--- a/purge/Services/CacheScanner.swift
+++ b/purge/Services/CacheScanner.swift
@@ -139,6 +139,7 @@ final class CacheScanner {
             let url = location.url.standardizedFileURL
             guard FileManager.default.fileExists(atPath: url.path) else { continue }
             guard DeletionSafetyPolicy.isOfferedForCleanup(url) else { continue }
+            guard !ExcludedPathsStore.isExcluded(url) else { continue }
             let folderName = url.lastPathComponent
             let safetyInfo = ExplanationResolver.initialSafetyForCacheFolder(
                 folderName: folderName,
@@ -193,6 +194,7 @@ final class CacheScanner {
 
             let pathKey = directory.standardizedFileURL.path
             guard DeletionSafetyPolicy.isOfferedForCleanup(directory) else { return nil }
+            guard !ExcludedPathsStore.isExcluded(directory) else { return nil }
             guard !collectedPaths.contains(pathKey) else { return nil }
             collectedPaths.insert(pathKey)
 
@@ -325,6 +327,7 @@ final class CacheScanner {
             let headline = "\(appName) Old Version \(version)"
             let pathKey = frameworkVersionURL.standardizedFileURL.path
             guard DeletionSafetyPolicy.isOfferedForCleanup(frameworkVersionURL) else { continue }
+            guard !ExcludedPathsStore.isExcluded(frameworkVersionURL) else { continue }
             guard !collectedPaths.contains(pathKey) else { continue }
             collectedPaths.insert(pathKey)
 
@@ -360,6 +363,7 @@ final class CacheScanner {
     ) -> CacheItem? {
         let pathKey = url.standardizedFileURL.path
         guard DeletionSafetyPolicy.isOfferedForCleanup(url) else { return nil }
+        guard !ExcludedPathsStore.isExcluded(url) else { return nil }
         guard !collectedPaths.contains(pathKey) else { return nil }
         collectedPaths.insert(pathKey)
 

--- a/purge/Services/DevScanner.swift
+++ b/purge/Services/DevScanner.swift
@@ -203,10 +203,9 @@ final class DevScanner {
         guard FileManager.default.fileExists(atPath: devicesRoot.path) else { return [] }
         guard FileManager.default.isExecutableFile(atPath: Self.xcrunPath) else { return [] }
 
-        if let fromSimctl = await loadSimulatorsFromSimctl(devicesRoot: devicesRoot) {
-            return fromSimctl
-        }
-        return loadSimulatorsFromPlistFiles(devicesRoot: devicesRoot)
+        let devices = await loadSimulatorsFromSimctl(devicesRoot: devicesRoot)
+            ?? loadSimulatorsFromPlistFiles(devicesRoot: devicesRoot)
+        return devices.filter { !ExcludedPathsStore.isExcluded($0.folderURL) }
     }
 
     private static let xcrunPath = "/usr/bin/xcrun"
@@ -520,6 +519,7 @@ final class DevScanner {
             let existing = paths.filter {
                 FileManager.default.fileExists(atPath: $0.path)
                     && DeletionSafetyPolicy.isOfferedForCleanup($0)
+                    && !ExcludedPathsStore.isExcluded($0)
             }
             guard !existing.isEmpty else { return nil }
 
@@ -1015,6 +1015,9 @@ final class DevScanner {
         func addIfDir(kind: DeletableArtifactKind, url: URL) {
             guard fm.fileExists(atPath: url.path) else { return }
             guard DeletionSafetyPolicy.isOfferedForCleanup(url) else { return }
+            // Also drops every artifact under an excluded project root, since the store
+            // matches ancestors — that is how a whole-project exclusion takes effect.
+            guard !ExcludedPathsStore.isExcluded(url) else { return }
             var isDir = false
             if let rv = try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory {
                 isDir = rv

--- a/purge/Services/ExcludedPathsStore.swift
+++ b/purge/Services/ExcludedPathsStore.swift
@@ -54,7 +54,16 @@ enum ExcludedPathsStore {
         else {
             return [:]
         }
-        return decoded
+        // Entries persisted before keys resolved symlinks are re-keyed on load, so an
+        // existing exclusion keeps matching instead of silently going stale.
+        return decoded.reduce(into: [String: ExcludedPathEntry]()) { result, pair in
+            let key = canonicalKey(forPath: URL(fileURLWithPath: pair.value.path))
+            result[key] = ExcludedPathEntry(
+                path: key,
+                displayName: pair.value.displayName,
+                dateAdded: pair.value.dateAdded
+            )
+        }
     }
 
     nonisolated private static func loadEntriesLocked() -> [String: ExcludedPathEntry] {
@@ -72,8 +81,12 @@ enum ExcludedPathsStore {
         loadedEntries = entries
     }
 
+    /// Resolves symlinks so a path reached through different chains (`/tmp/x` vs
+    /// `/private/tmp/x`, or a symlinked project root) yields one key. Every read and
+    /// write routes through here, including entries loaded from disk, so the ancestor
+    /// prefix match in `isExcluded` never compares a resolved path to an unresolved key.
     nonisolated private static func canonicalKey(forPath url: URL) -> String {
-        url.standardizedFileURL.path
+        url.standardizedFileURL.resolvingSymlinksInPath().path
     }
 
     nonisolated static func contains(path: URL) -> Bool {

--- a/purge/Services/ExcludedPathsStore.swift
+++ b/purge/Services/ExcludedPathsStore.swift
@@ -95,9 +95,8 @@ enum ExcludedPathsStore {
         return loadEntriesLocked()[canonicalKey(forPath: path)] != nil
     }
 
-    /// True when `url` is itself excluded, or lives inside an excluded folder.
-    /// Ancestor matching is component-wise so `/a/bc` is not treated as a child
-    /// of an excluded `/a/b`.
+    /// True when `url` is an excluded path or any descendant (component-wise prefix
+    /// match). Exclusions only subtract from allowlist-approved candidates.
     nonisolated static func isExcluded(_ url: URL) -> Bool {
         lock.lock()
         let keys = Set(loadEntriesLocked().keys)

--- a/purge/Services/ExcludedPathsStore.swift
+++ b/purge/Services/ExcludedPathsStore.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+struct ExcludedPathEntry: Codable, Sendable {
+    let path: String
+    let displayName: String
+    let dateAdded: Date
+
+    enum CodingKeys: String, CodingKey {
+        case path
+        case displayName
+        case dateAdded
+    }
+}
+
+/// Persists user-chosen scan exclusions keyed by exact filesystem path.
+/// An exclusion only ever removes a path the allowlist already approved: the
+/// scanner drops excluded paths *after* `DeletionSafetyPolicy.isOfferedForCleanup`,
+/// so un-excluding a path still requires it to pass the normal allowlist gate.
+enum ExcludedPathsStore {
+    nonisolated private static let lock = NSLock()
+    nonisolated(unsafe) private static var loadedEntries: [String: ExcludedPathEntry]?
+
+    nonisolated private static func supportURL() -> URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return base.appendingPathComponent("io.getpurge.app", isDirectory: true)
+    }
+
+    nonisolated static func fileURL() -> URL {
+        supportURL().appendingPathComponent("excluded_paths.json", isDirectory: false)
+    }
+
+    nonisolated private static func ensureDirectory() {
+        try? FileManager.default.createDirectory(at: supportURL(), withIntermediateDirectories: true)
+    }
+
+    nonisolated private static func makeDecoder() -> JSONDecoder {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }
+
+    nonisolated private static func makeEncoder() -> JSONEncoder {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        e.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return e
+    }
+
+    nonisolated private static func readFromDisk() -> [String: ExcludedPathEntry] {
+        ensureDirectory()
+        let url = fileURL()
+        guard let data = try? Data(contentsOf: url),
+              let decoded = try? makeDecoder().decode([String: ExcludedPathEntry].self, from: data)
+        else {
+            return [:]
+        }
+        return decoded
+    }
+
+    nonisolated private static func loadEntriesLocked() -> [String: ExcludedPathEntry] {
+        if let loadedEntries { return loadedEntries }
+        let disk = readFromDisk()
+        loadedEntries = disk
+        return disk
+    }
+
+    nonisolated private static func persistLocked(_ entries: [String: ExcludedPathEntry]) {
+        ensureDirectory()
+        if let data = try? makeEncoder().encode(entries) {
+            try? data.write(to: fileURL(), options: [.atomic])
+        }
+        loadedEntries = entries
+    }
+
+    nonisolated private static func canonicalKey(forPath url: URL) -> String {
+        url.standardizedFileURL.path
+    }
+
+    nonisolated static func contains(path: URL) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return loadEntriesLocked()[canonicalKey(forPath: path)] != nil
+    }
+
+    /// True when `url` is itself excluded, or lives inside an excluded folder.
+    /// Ancestor matching is component-wise so `/a/bc` is not treated as a child
+    /// of an excluded `/a/b`.
+    nonisolated static func isExcluded(_ url: URL) -> Bool {
+        lock.lock()
+        let keys = Set(loadEntriesLocked().keys)
+        lock.unlock()
+        guard !keys.isEmpty else { return false }
+
+        let path = canonicalKey(forPath: url)
+        if keys.contains(path) { return true }
+        return keys.contains { key in
+            key != path && path.hasPrefix(key.hasSuffix("/") ? key : key + "/")
+        }
+    }
+
+    nonisolated static func write(
+        path: URL,
+        displayName: String,
+        date: Date = Date()
+    ) {
+        lock.lock()
+        defer { lock.unlock() }
+        var entries = loadEntriesLocked()
+        let key = canonicalKey(forPath: path)
+        entries[key] = ExcludedPathEntry(
+            path: key,
+            displayName: displayName,
+            dateAdded: date
+        )
+        persistLocked(entries)
+    }
+
+    nonisolated static func remove(path: URL) {
+        lock.lock()
+        defer { lock.unlock() }
+        var entries = loadEntriesLocked()
+        guard entries.removeValue(forKey: canonicalKey(forPath: path)) != nil else { return }
+        persistLocked(entries)
+    }
+
+    nonisolated static func allExcludedPaths() -> Set<String> {
+        lock.lock()
+        defer { lock.unlock() }
+        return Set(loadEntriesLocked().keys)
+    }
+
+    nonisolated static func allEntries() -> [ExcludedPathEntry] {
+        lock.lock()
+        defer { lock.unlock() }
+        return loadEntriesLocked().values.sorted { lhs, rhs in
+            lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+        }
+    }
+
+    nonisolated static func count() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return loadEntriesLocked().count
+    }
+
+    /// Modification date of `excluded_paths.json`, if the file exists on disk.
+    nonisolated static func lastUpdated() -> Date? {
+        let url = fileURL()
+        guard FileManager.default.fileExists(atPath: url.path),
+              let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
+        else { return nil }
+        return attrs[.modificationDate] as? Date
+    }
+}

--- a/purge/Services/PurgeStore.swift
+++ b/purge/Services/PurgeStore.swift
@@ -2157,10 +2157,8 @@ final class PurgeStore: ObservableObject {
         excludedPaths = ExcludedPathsStore.allExcludedPaths()
     }
 
-    /// Exclude every location of a row from future scans and drop it from the current
-    /// results. Derived summaries recompute from `cacheItems`, so no totals are adjusted
-    /// by hand. Exclusion never widens what is scannable — it only removes an already
-    /// allowlisted item.
+    /// Subtracts every location from future scans and drops the row. Only removes paths
+    /// the allowlist already approved.
     func excludeFromScans(_ item: CacheItem) {
         for url in item.paths {
             ExcludedPathsStore.write(path: url, displayName: item.appName)
@@ -2191,7 +2189,8 @@ final class PurgeStore: ObservableObject {
         }
     }
 
-    /// Exclude every path backing a dev tool row and drop it from the current results.
+    /// Subtracts every path backing a dev tool row and drops it. Only removes paths the
+    /// allowlist already approved.
     func excludeFromScans(_ tool: DevTool) {
         for url in tool.paths {
             ExcludedPathsStore.write(path: url, displayName: tool.toolName)
@@ -2210,7 +2209,8 @@ final class PurgeStore: ObservableObject {
         }
     }
 
-    /// Exclude a simulator's device folder and drop it from the current results.
+    /// Subtracts a simulator device folder and drops it. Only removes paths the allowlist
+    /// already approved.
     func excludeFromScans(_ device: SimulatorDevice) {
         ExcludedPathsStore.write(
             path: device.folderURL,
@@ -2228,8 +2228,8 @@ final class PurgeStore: ObservableObject {
         }
     }
 
-    /// Exclude a single project artifact folder (e.g. one `node_modules`). The enclosing
-    /// group disappears too once its last artifact is gone.
+    /// Subtracts one artifact folder; the group vanishes once empty. Only removes paths
+    /// the allowlist already approved.
     func excludeProjectArtifactFromScans(groupID: String, artifactID: String) {
         guard let indices = projectArtifactIndices(groupID: groupID, artifactID: artifactID) else { return }
         let group = projectGroups[indices.groupIndex]
@@ -2248,8 +2248,8 @@ final class PurgeStore: ObservableObject {
         }
     }
 
-    /// Exclude an entire project root. `ExcludedPathsStore` matches descendants, so every
-    /// artifact under the root stays out of future scans without needing its own entry.
+    /// Subtracts a project root; descendant paths stay excluded via `isExcluded`. Only
+    /// removes paths the allowlist already approved.
     func excludeProjectGroupFromScans(groupID: String) {
         guard let group = projectGroups.first(where: { $0.id == groupID }) else { return }
         ExcludedPathsStore.write(path: group.rootPath, displayName: group.displayName)

--- a/purge/Services/PurgeStore.swift
+++ b/purge/Services/PurgeStore.swift
@@ -2168,6 +2168,23 @@ final class PurgeStore: ObservableObject {
         refreshExcludedPaths()
 
         let itemID = item.id
+        let excluded = Set(item.paths.map { $0.standardizedFileURL.path })
+
+        // A mid-scan flush republishes `cacheItems` from the staged buffer, so the row
+        // has to leave the buffer too or the next flush brings it straight back. Match on
+        // path as well as id: a staged twin can carry not-yet-sized locations that the
+        // published row dropped, which shifts its path-derived id.
+        stagedGeneralCacheItems = stagedGeneralCacheItems.compactMap { staged in
+            guard staged.id != itemID else { return nil }
+            let remaining = staged.locations.filter {
+                !excluded.contains($0.path.standardizedFileURL.path)
+            }
+            guard !remaining.isEmpty else { return nil }
+            guard remaining.count != staged.locations.count else { return staged }
+            return staged.withLocations(remaining)
+        }
+        pendingCacheSizePaths.subtract(excluded)
+
         scanSelection.cacheIDs.remove(itemID)
         withAnimation {
             cacheItems.removeAll { $0.id == itemID }
@@ -2182,6 +2199,11 @@ final class PurgeStore: ObservableObject {
         refreshExcludedPaths()
 
         let toolID = tool.id
+        // A pending size update re-adds a staged tool to `devTools` when it lands, so drop
+        // the staged copy and stop waiting on its size.
+        stagedDevToolsByID.removeValue(forKey: toolID)
+        pendingDevToolSizeIDs.remove(toolID)
+
         scanSelection.devToolIDs.remove(toolID)
         withAnimation {
             devTools.removeAll { $0.id == toolID }
@@ -2197,6 +2219,9 @@ final class PurgeStore: ObservableObject {
         refreshExcludedPaths()
 
         let deviceID = device.id
+        // Same as dev tools: a staged simulator is re-appended once its size resolves.
+        stagedSimulatorsByID.removeValue(forKey: deviceID)
+
         scanSelection.simulatorIDs.remove(deviceID)
         withAnimation {
             simulatorDevices.removeAll { $0.id == deviceID }

--- a/purge/Services/PurgeStore.swift
+++ b/purge/Services/PurgeStore.swift
@@ -166,6 +166,9 @@ final class PurgeStore: ObservableObject {
 
     /// Standardized paths with manual user categorizations. Mirrors `user_overrides.json`.
     @Published private(set) var userOverridePaths: Set<String> = UserOverridesStore.allOverriddenPaths()
+    /// Paths the user excluded from scans. Purely subtractive: the scanner drops these
+    /// after the allowlist gate, so nothing new ever becomes scannable or cleanable.
+    @Published private(set) var excludedPaths: Set<String> = ExcludedPathsStore.allExcludedPaths()
 
     private let cacheScanner = CacheScanner()
     private let devScanner = DevScanner()
@@ -2148,6 +2151,96 @@ final class PurgeStore: ObservableObject {
 
     private func refreshUserOverridePaths() {
         userOverridePaths = UserOverridesStore.allOverriddenPaths()
+    }
+
+    private func refreshExcludedPaths() {
+        excludedPaths = ExcludedPathsStore.allExcludedPaths()
+    }
+
+    /// Exclude every location of a row from future scans and drop it from the current
+    /// results. Derived summaries recompute from `cacheItems`, so no totals are adjusted
+    /// by hand. Exclusion never widens what is scannable — it only removes an already
+    /// allowlisted item.
+    func excludeFromScans(_ item: CacheItem) {
+        for url in item.paths {
+            ExcludedPathsStore.write(path: url, displayName: item.appName)
+        }
+        refreshExcludedPaths()
+
+        let itemID = item.id
+        scanSelection.cacheIDs.remove(itemID)
+        withAnimation {
+            cacheItems.removeAll { $0.id == itemID }
+        }
+    }
+
+    /// Exclude every path backing a dev tool row and drop it from the current results.
+    func excludeFromScans(_ tool: DevTool) {
+        for url in tool.paths {
+            ExcludedPathsStore.write(path: url, displayName: tool.toolName)
+        }
+        refreshExcludedPaths()
+
+        let toolID = tool.id
+        scanSelection.devToolIDs.remove(toolID)
+        withAnimation {
+            devTools.removeAll { $0.id == toolID }
+        }
+    }
+
+    /// Exclude a simulator's device folder and drop it from the current results.
+    func excludeFromScans(_ device: SimulatorDevice) {
+        ExcludedPathsStore.write(
+            path: device.folderURL,
+            displayName: "\(device.deviceName) — \(device.runtimeVersion)"
+        )
+        refreshExcludedPaths()
+
+        let deviceID = device.id
+        scanSelection.simulatorIDs.remove(deviceID)
+        withAnimation {
+            simulatorDevices.removeAll { $0.id == deviceID }
+        }
+    }
+
+    /// Exclude a single project artifact folder (e.g. one `node_modules`). The enclosing
+    /// group disappears too once its last artifact is gone.
+    func excludeProjectArtifactFromScans(groupID: String, artifactID: String) {
+        guard let indices = projectArtifactIndices(groupID: groupID, artifactID: artifactID) else { return }
+        let group = projectGroups[indices.groupIndex]
+        let artifact = group.artifacts[indices.artifactIndex]
+        ExcludedPathsStore.write(
+            path: artifact.path,
+            displayName: "\(group.displayName) — \(artifact.kind.rowTag)"
+        )
+        refreshExcludedPaths()
+
+        scanSelection.artifactIDs.remove(artifactID)
+        withAnimation {
+            var groups = projectGroups
+            groups[indices.groupIndex].artifacts.removeAll { $0.id == artifactID }
+            projectGroups = groups.filter { !$0.artifacts.isEmpty }
+        }
+    }
+
+    /// Exclude an entire project root. `ExcludedPathsStore` matches descendants, so every
+    /// artifact under the root stays out of future scans without needing its own entry.
+    func excludeProjectGroupFromScans(groupID: String) {
+        guard let group = projectGroups.first(where: { $0.id == groupID }) else { return }
+        ExcludedPathsStore.write(path: group.rootPath, displayName: group.displayName)
+        refreshExcludedPaths()
+
+        scanSelection.artifactIDs.subtract(group.artifacts.map(\.id))
+        withAnimation {
+            projectGroups.removeAll { $0.id == groupID }
+        }
+    }
+
+    /// Drop an exclusion. The item reappears on the next scan, but only if it still
+    /// passes the normal allowlist gate.
+    func removeExclusion(path: URL) {
+        ExcludedPathsStore.remove(path: path)
+        refreshExcludedPaths()
     }
 
     /// Mark a row with a manual category. Persists `user_overrides.json` keyed

--- a/purge/Views/DevModeView.swift
+++ b/purge/Views/DevModeView.swift
@@ -705,6 +705,7 @@ struct DevToolsView<PageHeader: View>: View {
                             reinstallSafety: tool.reinstallSafety,
                             showUncommittedRepoChanges: !isDevToolMetadataPending(tool) && toolShowsUncommitted(tool),
                             onResetToAutomatic: primaryPath != nil ? { store.resetDevToolToAutomatic(id: toolID) } : nil,
+                            onExcludeFromScans: { store.excludeFromScans(tool) },
                             isUserOverride: primaryPath.map { store.userOverridePaths.contains($0.standardizedFileURL.path) } ?? false,
                             isMetadataPending: isDevToolMetadataPending(tool)
                         )
@@ -748,6 +749,7 @@ struct DevToolsView<PageHeader: View>: View {
                                     reinstallSafety: .notApplicable,
                                     showUncommittedRepoChanges: false,
                                     onResetToAutomatic: nil,
+                                    onExcludeFromScans: { store.excludeFromScans(device) },
                                     isUserOverride: false,
                                     allowsBulkSelection: true,
                                     isMetadataPending: isSimulatorMetadataPending(device),
@@ -930,6 +932,15 @@ struct DevToolsView<PageHeader: View>: View {
             .padding(.vertical, 2)
             .padding(.horizontal, AppStyle.Spacing.xSmall)
             .frame(minHeight: AppStyle.Row.parentHeight)
+            // Header only: an overlay across the whole card would swallow the
+            // right-click meant for an individual artifact row.
+            .overlay {
+                ScanRowContextMenu(
+                    isMenuActive: .constant(false),
+                    title: "Exclude project from scans",
+                    action: { store.excludeProjectGroupFromScans(groupID: group.id) }
+                )
+            }
 
             if isExpanded {
                 projectArtifactRows(groupIndex: currentGroupIndex)
@@ -993,6 +1004,9 @@ struct DevToolsView<PageHeader: View>: View {
                     reinstallSafety: nil,
                     showUncommittedRepoChanges: !isArtifactMetadataPending(art) && art.gitStatus == .dirty,
                     onResetToAutomatic: { store.resetProjectArtifactToAutomatic(groupID: groupID, artifactID: artifactID) },
+                    onExcludeFromScans: {
+                        store.excludeProjectArtifactFromScans(groupID: groupID, artifactID: artifactID)
+                    },
                     isUserOverride: store.userOverridePaths.contains(artifactPath),
                     showsBulkCheckbox: false,
                     isMetadataPending: isArtifactMetadataPending(art) || store.projectArtifactHasPendingSize(art),

--- a/purge/Views/GeneralModeView.swift
+++ b/purge/Views/GeneralModeView.swift
@@ -333,6 +333,7 @@ struct AppCachesView<PageHeader: View>: View {
                         reinstallSafety: reinstallDisplay(for: item),
                         showUncommittedRepoChanges: item.gitStatus == .dirty,
                         onResetToAutomatic: { store.resetCacheItemToAutomatic(id: itemID) },
+                        onExcludeFromScans: { store.excludeFromScans(item) },
                         isUserOverride: item.locations.contains {
                             store.userOverridePaths.contains($0.path.standardizedFileURL.path)
                         },

--- a/purge/Views/ScanResultRow.swift
+++ b/purge/Views/ScanResultRow.swift
@@ -174,6 +174,9 @@ struct ScanResultRow: View {
                     action: onExcludeFromScans
                 )
             }
+            // The overlay only answers a secondary click, which VoiceOver and the
+            // keyboard cannot produce; this exposes the same action to them.
+            .accessibilityAction(named: Text("Exclude from scans"), onExcludeFromScans)
         } else {
             row
         }
@@ -448,7 +451,7 @@ struct ScanRowContextMenu: NSViewRepresentable {
             item.target = self
             menu.addItem(item)
             menu.delegate = menuDelegate
-            NSMenu.popUpContextMenu(menu, with: event, for: self)
+            menu.popUp(positioning: nil, at: convert(event.locationInWindow, from: nil), in: self)
         }
 
         @objc private func performAction() {

--- a/purge/Views/ScanResultRow.swift
+++ b/purge/Views/ScanResultRow.swift
@@ -43,6 +43,9 @@ struct ScanResultRow: View {
     /// Clears a legacy manual category override. When nil, the corresponding
     /// badge is hidden.
     let onResetToAutomatic: (() -> Void)?
+    /// Adds the row's paths to the scan exclusions. When nil, no exclusion menu entry
+    /// is offered.
+    var onExcludeFromScans: (() -> Void)?
     let isUserOverride: Bool
     /// When `false`, the row checkbox is disabled (e.g. high-risk items that should not participate in bulk select).
     var allowsBulkSelection: Bool = true
@@ -58,6 +61,7 @@ struct ScanResultRow: View {
     var usesCompactExplanation: Bool = false
 
     @Environment(\.scanRowPlaceholderAppearance) private var rendersAsPlaceholder
+    @State private var isContextMenuActive = false
 
     private var statusLabel: String {
         safetyInfo.level.displayName
@@ -117,6 +121,7 @@ struct ScanResultRow: View {
         reinstallSafety: ReinstallSafetyStatus? = nil,
         showUncommittedRepoChanges: Bool = false,
         onResetToAutomatic: (() -> Void)? = nil,
+        onExcludeFromScans: (() -> Void)? = nil,
         isUserOverride: Bool = false,
         allowsBulkSelection: Bool = true,
         showsBulkCheckbox: Bool = true,
@@ -135,6 +140,7 @@ struct ScanResultRow: View {
         self.reinstallSafety = reinstallSafety
         self.showUncommittedRepoChanges = showUncommittedRepoChanges
         self.onResetToAutomatic = onResetToAutomatic
+        self.onExcludeFromScans = onExcludeFromScans
         self.isUserOverride = isUserOverride
         self.allowsBulkSelection = allowsBulkSelection
         self.showsBulkCheckbox = showsBulkCheckbox
@@ -144,9 +150,33 @@ struct ScanResultRow: View {
         self.usesCompactExplanation = usesCompactExplanation
     }
 
+    @ViewBuilder
     var body: some View {
-        rowBody
-            .modifier(ScanResultRowChrome(showsCardChrome: showsCardChrome, canSelectForBulk: canSelectForBulk))
+        let row = rowBody
+            .modifier(
+                ScanResultRowChrome(
+                    showsCardChrome: showsCardChrome,
+                    canSelectForBulk: canSelectForBulk,
+                    showsContextMenuHighlight: isContextMenuActive
+                )
+            )
+            .animation(.easeOut(duration: 0.12), value: isContextMenuActive)
+
+        if let onExcludeFromScans {
+            // Not SwiftUI's `.contextMenu`: that hands the menu to the enclosing
+            // NSTableView, which then paints its own blue contextual-menu highlight
+            // around the whole list row. Consuming the right-click ourselves keeps
+            // the table out of it; we draw our own neutral row emphasis instead.
+            row.overlay {
+                ScanRowContextMenu(
+                    isMenuActive: $isContextMenuActive,
+                    title: "Exclude from scans",
+                    action: onExcludeFromScans
+                )
+            }
+        } else {
+            row
+        }
     }
 
     @ViewBuilder
@@ -370,20 +400,134 @@ struct ScanResultRow: View {
     }
 }
 
+// MARK: - Row context menu
+
+/// A single-item right-click menu for a scan row. It handles `rightMouseDown` itself
+/// and never forwards it, so the List's backing NSTableView never treats the row as a
+/// contextual-menu target and never draws the blue row highlight around it. Left clicks
+/// fall through untouched, so row selection still works. While the menu is open, the
+/// parent row shows a neutral emphasis ring via `isMenuActive`.
+struct ScanRowContextMenu: NSViewRepresentable {
+    @Binding var isMenuActive: Bool
+    let title: String
+    let action: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator: NSObject, NSMenuDelegate {
+        var onMenuClosed: (() -> Void)?
+
+        func menuDidClose(_ menu: NSMenu) {
+            DispatchQueue.main.async { [weak self] in
+                self?.onMenuClosed?()
+            }
+        }
+    }
+
+    final class MenuHostView: NSView {
+        weak var menuDelegate: NSMenuDelegate?
+        var title = ""
+        var action: () -> Void = {}
+        var onMenuOpened: (() -> Void)?
+
+        override func rightMouseDown(with event: NSEvent) {
+            showMenu(for: event)
+        }
+
+        /// Control-click arrives as a left click with the control modifier.
+        override func mouseDown(with event: NSEvent) {
+            showMenu(for: event)
+        }
+
+        private func showMenu(for event: NSEvent) {
+            onMenuOpened?()
+            let menu = NSMenu()
+            let item = NSMenuItem(title: title, action: #selector(performAction), keyEquivalent: "")
+            item.target = self
+            menu.addItem(item)
+            menu.delegate = menuDelegate
+            NSMenu.popUpContextMenu(menu, with: event, for: self)
+        }
+
+        @objc private func performAction() {
+            action()
+        }
+
+        /// Claim secondary clicks only; every other event passes to the SwiftUI row beneath.
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            guard let event = NSApp.currentEvent else { return nil }
+            switch event.type {
+            case .rightMouseDown, .rightMouseUp:
+                return super.hitTest(point)
+            case .leftMouseDown, .leftMouseUp:
+                return event.modifierFlags.contains(.control) ? super.hitTest(point) : nil
+            default:
+                return nil
+            }
+        }
+    }
+
+    func makeNSView(context: Context) -> MenuHostView {
+        let view = MenuHostView()
+        view.title = title
+        view.action = action
+        wire(view: view, coordinator: context.coordinator)
+        return view
+    }
+
+    func updateNSView(_ nsView: MenuHostView, context: Context) {
+        nsView.title = title
+        nsView.action = action
+        wire(view: nsView, coordinator: context.coordinator)
+    }
+
+    private func wire(view: MenuHostView, coordinator: Coordinator) {
+        view.menuDelegate = coordinator
+        view.onMenuOpened = { isMenuActive = true }
+        coordinator.onMenuClosed = { isMenuActive = false }
+    }
+}
+
 // MARK: - Row chrome
 
 struct ScanRowCardChrome: ViewModifier {
     var showsCardChrome: Bool = true
     var canSelectForBulk: Bool = true
+    var showsContextMenuHighlight: Bool = false
+
+    private var cardShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: AppStyle.Radius.panel, style: .continuous)
+    }
 
     func body(content: Content) -> some View {
         if showsCardChrome {
             content
-                .background(Color.primary.opacity(0.05))
-                .clipShape(RoundedRectangle(cornerRadius: AppStyle.Radius.panel, style: .continuous))
+                .background {
+                    cardShape
+                        .fill(
+                            showsContextMenuHighlight
+                                ? Color.primary.opacity(0.10)
+                                : Color.primary.opacity(0.05)
+                        )
+                }
+                .clipShape(cardShape)
+                .overlay {
+                    if showsContextMenuHighlight {
+                        cardShape
+                            .strokeBorder(AppColors.borderSubtle, lineWidth: 1)
+                    }
+                }
                 .opacity(canSelectForBulk ? 1 : 0.55)
         } else {
             content
+                .background {
+                    if showsContextMenuHighlight {
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .fill(Color.primary.opacity(0.08))
+                    }
+                }
                 .opacity(canSelectForBulk ? 1 : 0.55)
         }
     }

--- a/purge/Views/ScanResultRow.swift
+++ b/purge/Views/ScanResultRow.swift
@@ -43,8 +43,7 @@ struct ScanResultRow: View {
     /// Clears a legacy manual category override. When nil, the corresponding
     /// badge is hidden.
     let onResetToAutomatic: (() -> Void)?
-    /// Adds the row's paths to the scan exclusions. When nil, no exclusion menu entry
-    /// is offered.
+    /// When nil, the row omits the "Exclude from scans" context-menu action.
     var onExcludeFromScans: (() -> Void)?
     let isUserOverride: Bool
     /// When `false`, the row checkbox is disabled (e.g. high-risk items that should not participate in bulk select).
@@ -405,11 +404,8 @@ struct ScanResultRow: View {
 
 // MARK: - Row context menu
 
-/// A single-item right-click menu for a scan row. It handles `rightMouseDown` itself
-/// and never forwards it, so the List's backing NSTableView never treats the row as a
-/// contextual-menu target and never draws the blue row highlight around it. Left clicks
-/// fall through untouched, so row selection still works. While the menu is open, the
-/// parent row shows a neutral emphasis ring via `isMenuActive`.
+/// Right-click menu that consumes the click so NSTableView never paints its blue row
+/// highlight. Left clicks pass through for normal row selection.
 struct ScanRowContextMenu: NSViewRepresentable {
     @Binding var isMenuActive: Bool
     let title: String

--- a/purge/Views/SettingsView.swift
+++ b/purge/Views/SettingsView.swift
@@ -21,6 +21,9 @@ struct SettingsView: View {
     @State private var isCleaningHistoryExpanded = false
     @State private var showClearHistoryConfirmation = false
     @State private var selectedHistoryEntry: CleanupHistoryEntry?
+    /// Session cache of on-disk sizes for excluded paths, keyed by path. A `nil` value
+    /// means the path no longer exists.
+    @State private var excludedPathSizes: [String: Int64?] = [:]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -35,6 +38,7 @@ struct SettingsView: View {
                     appearanceSection
                     cleaningScheduleSection
                     devToolsSection
+                    excludedAppsSection
                     cleaningHistorySection
                 }
             }
@@ -373,6 +377,130 @@ struct SettingsView: View {
                 .padding(16)
             }
         }
+    }
+
+    /// Paths the user removed from scanning. Purely subtractive: an excluded path is
+    /// dropped at discovery, and un-excluding it only makes it eligible again if it
+    /// still passes the normal safety allowlist.
+    private var excludedAppsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Excluded from scans")
+                .font(.headline)
+
+            settingsSectionCard {
+                Text("Excluded paths are never scanned or cleaned. Right-click any scan result and choose 'Exclude from scans'.")
+                    .font(scheduleStatusSecondaryFont)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(16)
+
+                let entries = excludedEntries
+
+                if entries.isEmpty {
+                    settingsSectionDivider
+
+                    Text("Nothing excluded")
+                        .font(scheduleStatusPrimaryFont)
+                        .foregroundStyle(.secondary)
+                        .padding(16)
+                } else {
+                    ForEach(entries, id: \.path) { entry in
+                        settingsSectionDivider
+
+                        excludedPathRow(entry: entry)
+                    }
+
+                    settingsSectionDivider
+
+                    excludedTotalRow(entries: entries)
+                }
+            }
+        }
+    }
+
+    private var excludedEntries: [ExcludedPathEntry] {
+        ExcludedPathsStore.allEntries()
+    }
+
+    private func excludedPathRow(entry: ExcludedPathEntry) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(entry.displayName)
+                    .font(scheduleStatusPrimaryFont)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Text(entry.path)
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Spacer(minLength: 12)
+
+            excludedSizeLabel(forPath: entry.path)
+
+            statusTextButton("Remove", isDisabled: false) {
+                removeExclusion(entry: entry)
+            }
+        }
+        .padding(16)
+        .task(id: entry.path) {
+            await loadExcludedSizeIfNeeded(forPath: entry.path)
+        }
+    }
+
+    @ViewBuilder
+    private func excludedSizeLabel(forPath path: String) -> some View {
+        if let resolved = excludedPathSizes[path] {
+            Text(resolved.map(formatBytes) ?? "Not found")
+                .font(scheduleStatusSecondaryFont)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        } else {
+            SkeletonBar(width: 56, height: 12)
+                .shimmering()
+        }
+    }
+
+    private func excludedTotalRow(entries: [ExcludedPathEntry]) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            Text("Total")
+                .font(scheduleStatusPrimaryFont)
+                .foregroundStyle(AppColors.textSecondary)
+
+            Spacer(minLength: 12)
+
+            Text(formatBytes(excludedTotalBytes(for: entries)))
+                .font(scheduleStatusPrimaryFont)
+                .foregroundStyle(.primary)
+                .monospacedDigit()
+        }
+        .padding(16)
+    }
+
+    /// Sums the sizes resolved so far; unresolved and missing paths count as zero.
+    private func excludedTotalBytes(for entries: [ExcludedPathEntry]) -> Int64 {
+        entries.reduce(into: 0) { total, entry in
+            total += (excludedPathSizes[entry.path] ?? nil) ?? 0
+        }
+    }
+
+    private func loadExcludedSizeIfNeeded(forPath path: String) async {
+        guard excludedPathSizes[path] == nil else { return }
+        let url = URL(fileURLWithPath: path)
+        let size = await Task.detached(priority: .utility) { () -> Int64? in
+            guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+            return FolderSizing.directoryByteSize(at: url)
+        }.value
+        excludedPathSizes[path] = size
+    }
+
+    private func removeExclusion(entry: ExcludedPathEntry) {
+        store.removeExclusion(path: URL(fileURLWithPath: entry.path))
+        excludedPathSizes.removeValue(forKey: entry.path)
     }
 
     private func settingPickerRow<Option: Hashable>(

--- a/purge/Views/SettingsView.swift
+++ b/purge/Views/SettingsView.swift
@@ -379,9 +379,8 @@ struct SettingsView: View {
         }
     }
 
-    /// Paths the user removed from scanning. Purely subtractive: an excluded path is
-    /// dropped at discovery, and un-excluding it only makes it eligible again if it
-    /// still passes the normal safety allowlist.
+    /// Settings section for scan exclusions. Purely subtractive: un-excluding only restores
+    /// eligibility when the path still passes the normal allowlist gate.
     private var excludedAppsSection: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("Excluded from scans")


### PR DESCRIPTION
Add an "Excluded from scans" feature so specific apps or paths can be excluded from cache scanning.

Exclusions are a subtractive filter applied alongside the existing allowlist gate, so they can only ever remove an approved candidate, never expand what Purge can touch. Settings lists each excluded path explicitly with its current on-disk size.

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Exclude from scans” actions for cache items, developer tools, simulators, and project artifacts/groups.
  * Excluded locations are now consistently filtered out from discovery and cleanup suggestions, including ancestor-based matches.
  * Added a Settings section to view excluded paths, see their resolved total size, and remove exclusions.
  * Enhanced scan result rows with right-/control-click context menus and a visual highlight while the menu is open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->