### PR TITLE
fix: match Telegram media cache when account-* sits at the container root

### DIFF
--- a/PurgeTests/DeletionSafetyPolicyTests.swift
+++ b/PurgeTests/DeletionSafetyPolicyTests.swift
@@ -362,6 +362,117 @@ struct TelegramMediaCacheTests {
             #expect(DeletionSafetyPolicy.isOfferedForCleanup(surfaced.url))
         }
     }
+
+    @Test
+    func accountsDirectlyUnderTheContainerRootAreAllowed() {
+        // The distribution-channel segment is optional; some installs keep
+        // `account-*` at the container root.
+        let media = TestPaths.homeURL(Self.container + ["account-7", "postbox", "media"])
+        #expect(DeletionSafetyPolicy.evaluate(media) == .allow)
+        #expect(DeletionSafetyPolicy.shouldDeleteContentsOnly(media))
+
+        let db = TestPaths.homeURL(Self.container + ["account-7", "postbox", "db"])
+        #expect(DeletionSafetyPolicy.evaluate(db) != .allow)
+    }
+
+    @Test
+    func accountSettingsFilesAreNeverAllowed() {
+        // Account-level settings/database files sit beside `postbox`, not below
+        // `media`, so no tier may reach them.
+        let settings = TestPaths.homeURL(
+            Self.container + ["stable", "account-1", "settings.db"]
+        )
+        #expect(DeletionSafetyPolicy.evaluate(settings) != .allow)
+
+        let accountDB = TestPaths.homeURL(
+            Self.container + ["stable", "account-1", "postbox", "db", "db_sqlite"]
+        )
+        #expect(DeletionSafetyPolicy.evaluate(accountDB) != .allow)
+    }
+
+    @Test
+    func mediaCannotTraverseOutToASiblingOfItself() {
+        // `..` traversal out of `media` must not stay authorized: the policy
+        // standardizes the path first, so the escape resolves to `postbox/db`
+        // and is refused.
+        let escape = Self.mediaURL(
+            channel: "stable", account: "account-1", extra: "..", "db"
+        )
+        #expect(escape.standardizedFileURL.path.hasSuffix("/postbox/db"))
+        #expect(DeletionSafetyPolicy.evaluate(escape) != .allow)
+
+        let escapeToPostbox = Self.mediaURL(channel: "stable", account: "account-1", extra: "..")
+        #expect(DeletionSafetyPolicy.evaluate(escapeToPostbox) != .allow)
+
+        // ...and a deeper traversal cannot climb back out to the container root.
+        let escapeToRoot = Self.mediaURL(
+            channel: "stable", account: "account-1", extra: "..", "..", ".."
+        )
+        #expect(DeletionSafetyPolicy.evaluate(escapeToRoot) != .allow)
+    }
+
+    @Test
+    func mediaSuffixIsNotMatchedAtArbitraryDepth() {
+        // A nested `account-*/postbox/media` triple buried deeper in the
+        // container is not the real media store and must not be authorized.
+        let deep = TestPaths.homeURL(
+            Self.container + ["stable", "extra", "account-1", "postbox", "media"]
+        )
+        #expect(DeletionSafetyPolicy.evaluate(deep) != .allow)
+    }
+}
+
+// MARK: - Group 3d: Telegram's two locations sit in different tiers
+
+@Suite("Telegram cache is Safe to Clean; Telegram media store is Check First")
+struct TelegramSafetyTierTests {
+    private static func level(folderName: String, path: URL) -> SafetyLevel? {
+        if let record = ExplanationDatabase.matchBundledDatabase(folderName: folderName) {
+            return record.safetyLevel
+        }
+        return SafetyTierList.evaluate(folderName: folderName, path: path)
+    }
+
+    @Test
+    func pureCacheUnderLibraryCachesIsSafeToClean() {
+        // ~/Library/Caches/ru.keepcoder.Telegram — an evictable HTTP-style cache.
+        // Worst case on deletion is a rebuild.
+        let file = TestPaths.homeURL(
+            "Library", "Caches", "ru.keepcoder.Telegram", "cache", "blob-1"
+        )
+        #expect(DeletionSafetyPolicy.evaluate(file) == .allow)
+        #expect(Self.level(folderName: "ru.keepcoder.Telegram", path: file) == .safe)
+    }
+
+    @Test
+    func groupContainerMediaStoreIsCheckFirst() {
+        // The media store holds re-downloadable media, but also self-destruct and
+        // server-deleted content whose only copy is local — reviewable, never one-tap.
+        let media = TestPaths.homeURL([
+            "Library", "Group Containers", "6N38VWS5BX.ru.keepcoder.Telegram",
+            "stable", "account-1", "postbox", "media"
+        ])
+        #expect(DeletionSafetyPolicy.evaluate(media) == .allow)
+        #expect(
+            Self.level(folderName: CacheDiscoveryPaths.telegramMediaCacheKey, path: media) == .medium
+        )
+    }
+
+    @Test
+    func theTwoLocationsDoNotShareATier() {
+        let cacheLevel = Self.level(
+            folderName: "ru.keepcoder.Telegram",
+            path: TestPaths.homeURL("Library", "Caches", "ru.keepcoder.Telegram")
+        )
+        let mediaLevel = Self.level(
+            folderName: CacheDiscoveryPaths.telegramMediaCacheKey,
+            path: TestPaths.homeURL([
+                "Library", "Group Containers", "6N38VWS5BX.ru.keepcoder.Telegram",
+                "stable", "account-1", "postbox", "media"
+            ])
+        )
+        #expect(cacheLevel != mediaLevel)
+    }
 }
 
 // MARK: - Group 4: Whitelisted folder names inside home

--- a/purge/Services/CacheDiscoveryPaths.swift
+++ b/purge/Services/CacheDiscoveryPaths.swift
@@ -142,9 +142,9 @@ enum CacheDiscoveryPaths {
     /// broad Caches sweep never reaches them. Only the `postbox/media` directory
     /// is ever targeted — never `postbox` itself, which holds the account
     /// database whose removal would log the user out or lose local data. The
-    /// `*` segment covers the distribution channel (stable, appstore, and any
-    /// future channel); `account-*` covers every signed-in account. The match
-    /// still terminates at `postbox/media` exactly.
+    /// optional leading segment covers the distribution channel (stable,
+    /// appstore, and any future channel); `account-*` covers every signed-in
+    /// account. The match still terminates at `postbox/media` exactly.
     nonisolated static let telegramGroupContainerRelative =
         "Library/Group Containers/6N38VWS5BX.ru.keepcoder.Telegram"
 
@@ -152,7 +152,7 @@ enum CacheDiscoveryPaths {
     /// and the headline shown in the list.
     nonisolated static let telegramMediaCacheKey = "Telegram Media Cache"
 
-    /// Existing `.../<channel>/account-*/postbox/media` directories across all
+    /// Existing `.../[channel/]account-*/postbox/media` directories across all
     /// distribution channels and signed-in accounts. Absent folders (Telegram
     /// not installed) simply yield nothing — never an error row.
     nonisolated static func telegramMediaCacheURLs(
@@ -177,21 +177,26 @@ enum CacheDiscoveryPaths {
             }
         }
 
+        // `account-*` — one directory per signed-in account. Accounts usually sit
+        // under a distribution channel dir (stable, appstore, any future channel),
+        // but some installs place them straight at the container root.
+        var accountDirs = subdirectories(of: root, namePrefix: "account-")
+        for channelDir in subdirectories(of: root)
+        where !channelDir.lastPathComponent.hasPrefix("account-") {
+            accountDirs.append(contentsOf: subdirectories(of: channelDir, namePrefix: "account-"))
+        }
+
         var results: [(url: URL, headline: String, key: String)] = []
-        // `*` — distribution channel (stable, appstore, any future channel).
-        for channelDir in subdirectories(of: root) {
-            // `account-*` — one directory per signed-in account.
-            for accountDir in subdirectories(of: channelDir, namePrefix: "account-") {
-                let media = accountDir
-                    .appendingPathComponent("postbox", isDirectory: true)
-                    .appendingPathComponent("media", isDirectory: true)
-                    .standardizedFileURL
-                var isDir: ObjCBool = false
-                guard fm.fileExists(atPath: media.path, isDirectory: &isDir), isDir.boolValue else {
-                    continue
-                }
-                results.append((media, telegramMediaCacheKey, telegramMediaCacheKey))
+        for accountDir in accountDirs {
+            let media = accountDir
+                .appendingPathComponent("postbox", isDirectory: true)
+                .appendingPathComponent("media", isDirectory: true)
+                .standardizedFileURL
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: media.path, isDirectory: &isDir), isDir.boolValue else {
+                continue
             }
+            results.append((media, telegramMediaCacheKey, telegramMediaCacheKey))
         }
         return results
     }

--- a/purge/Services/DeletionSafetyPolicy.swift
+++ b/purge/Services/DeletionSafetyPolicy.swift
@@ -385,34 +385,45 @@ enum DeletionSafetyPolicy {
         return relative.split(separator: "/").map(String.init)
     }
 
+    /// Index at which the `account-*/postbox/media` suffix starts within a
+    /// container-relative split, or `nil` when the split never reaches it.
+    ///
+    /// Most installs nest accounts under a distribution channel (`stable`,
+    /// `appstore`); some place `account-*` directly at the container root, so
+    /// that segment is optional. Nothing deeper is searched: the suffix must
+    /// begin at the root or one level below it, which keeps the match anchored
+    /// to the real layout rather than any `account-*/postbox/media` triple that
+    /// happens to appear further down.
+    private nonisolated static func telegramMediaSuffixStart(_ parts: [String]) -> Int? {
+        for start in 0...1 where parts.count >= start + 3 {
+            guard parts[start].hasPrefix("account-"),
+                  parts[start + 1] == "postbox",
+                  parts[start + 2] == "media" else { continue }
+            return start
+        }
+        return nil
+    }
+
     /// Whether `path` is the Telegram `.../account-*/postbox/media` cache
     /// directory itself, or a descendant of it.
     ///
     /// The account database lives directly in `postbox`, so touching anything
     /// shallower would log the user out or lose local data. Authorization
-    /// requires the full `<channel>/account-*/postbox/media` suffix — `postbox`
-    /// itself and every ancestor can never match.
+    /// requires the full `account-*/postbox/media` suffix — `postbox` itself,
+    /// `postbox/db`, and every ancestor can never match.
     nonisolated static func isWhitelistedTelegramMediaCachePath(_ path: String, home: String) -> Bool {
         guard let parts = telegramGroupContainerRelativeParts(path, home: home) else { return false }
-        // channel / account-* / postbox / media  (media itself, or a descendant of it)
-        guard parts.count >= 4 else { return false }
-        guard !parts[0].isEmpty,
-              parts[1].hasPrefix("account-"),
-              parts[2] == "postbox",
-              parts[3] == "media" else { return false }
-        return true
+        // [channel/] account-* / postbox / media  (media itself, or a descendant)
+        return telegramMediaSuffixStart(parts) != nil
     }
 
     /// Whether `path` is exactly the Telegram `media` directory (not a
     /// descendant). Used to clean the directory's contents while leaving the
     /// `media` directory itself in place.
     nonisolated static func isTelegramMediaCacheDirectory(_ path: String, home: String) -> Bool {
-        guard let parts = telegramGroupContainerRelativeParts(path, home: home) else { return false }
-        guard parts.count == 4 else { return false }
-        return !parts[0].isEmpty
-            && parts[1].hasPrefix("account-")
-            && parts[2] == "postbox"
-            && parts[3] == "media"
+        guard let parts = telegramGroupContainerRelativeParts(path, home: home),
+              let start = telegramMediaSuffixStart(parts) else { return false }
+        return parts.count == start + 3
     }
 
     nonisolated static func isWhitelistedStaleBrowserFrameworkPath(_ path: String) -> Bool {


### PR DESCRIPTION
## Summary

The two-entry Telegram split (pure cache as Safe to Clean, media store as Check First) already existed on main. This PR does not add it. It closes two real gaps in the existing setup: the media cache was not matched or scanned on installs where `account-*` sits directly at the container root, and no test asserted that the two locations land in different tiers.

## Framing correction

`DeletionSafetyPolicy` is the deletion gate, not the scan source. Discovery lives in `CacheDiscoveryPaths` / `CacheScanner` and is filtered through the policy. A path the policy would authorize is still not scanned unless discovery walks to it. That is why the discovery fix touches two files.

## Already in place before this change

- Pure cache (`~/Library/Caches/ru.keepcoder.Telegram/`) authorized by the blanket `~/Library/Caches` prefix (`DeletionSafetyPolicy.swift:127`), classified Safe via the `telegram` record in `explanations.json` (tag: safe) and the `ru.keepcoder.Telegram` bundle prefix (`SafetyTierList.swift:66`).
- Media store authorized by `isWhitelistedTelegramMediaCachePath` (`DeletionSafetyPolicy.swift:395`), discovered by `CacheDiscoveryPaths.telegramMediaCacheURLs`, classified Check First via `telegram-media-cache` (tag: medium). The suffix match already required the full `account-*/postbox/media` path, so the container root, `postbox`, and `postbox/db` cannot resolve.

## Gap 1: the channel segment was treated as required

Both the match logic and discovery assumed exactly one channel segment (for example `stable/`) before `account-*`. An install with `account-*` at the container root was neither authorized nor scanned.

Fix: replaced the fixed-index check with `telegramMediaSuffixStart`, which anchors the `account-*/postbox/media` suffix at depth 0 or 1 only. This is deliberately not a `**` match at arbitrary depth, so a lookalike triple nested deeper in the container cannot match. `telegramMediaCacheURLs` now collects `account-*` from the container root as well as from each channel directory.

## Gap 2: nothing asserted the tiers

The existing tests only checked the deletion gate (`.allow` versus not). Nothing asserted that the two locations resolve to different tiers, which is the property that actually matters.

- New `TelegramSafetyTierTests`: cache resolves to `.safe`, media store to `.medium`, and the two levels differ.
- Added adversarial cases to `TelegramMediaCacheTests`: account settings files refused, `postbox/db/db_sqlite` refused, `..` traversal out of `media` (which standardizes to `postbox/db`, `postbox`, and the container root) refused, and the depth-2 glob-overreach case refused.

## Tests

15 Telegram tests pass. Full suite: 123 passed, 1 failed. The failure is `LargeFileScanPolicyTests/cacheSafetyStillBlocksPersonalMediaPaths`, a known pre-existing failure on clean main, unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Telegram media-cache discovery across supported container layouts.
  * Added support for accounts located directly in Telegram’s group container or within channel directories.

* **Bug Fixes**
  * Correctly recognizes eligible media directories while rejecting unrelated, sensitive, or path-traversal locations.
  * Preserves stricter protection for account settings and database files.

* **Tests**
  * Expanded coverage for Telegram cache authorization and safety-tier classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->