### PR TITLE
fix: skip the live cleanup screen during onboarding celebration

### DIFF
--- a/purge/ContentView.swift
+++ b/purge/ContentView.swift
@@ -630,6 +630,7 @@ struct SidebarSummaryView: View {
     @EnvironmentObject var store: PurgeStore
     @EnvironmentObject var diskStore: DiskSummaryStore
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @AppStorage("onboarding.pendingCelebration") private var pendingOnboardingCelebration = false
 
     private enum SummaryFont {
         static let label = Font.system(size: 12, weight: .medium, design: .rounded)
@@ -812,10 +813,12 @@ struct SidebarSummaryView: View {
 
     private func startInteractiveSafeCleanup() {
         let candidates = store.manualSafeCleanupCandidates()
+        // A pending onboarding celebration owns the post-clean screen; presenting
+        // the live session too would stack two summaries on the same run.
         guard store.beginInteractiveSafeCleanup(
             candidates: candidates,
             reduceMotion: reduceMotion,
-            presentsLiveSession: true
+            presentsLiveSession: !pendingOnboardingCelebration
         ) else { return }
 
         Task { @MainActor in


### PR DESCRIPTION
## Summary
- After the first cleanup during onboarding, only show the celebration — not the live cleanup screen as well
- Avoids stacking two post-clean summaries on the same run

## Test plan
- [ ] Complete onboarding and run the first safe cleanup; confirm the celebration appears and the live cleanup screen does not
- [ ] Run a safe cleanup outside onboarding; confirm the live cleanup screen still appears as usual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Safe Cleanup experience when an onboarding celebration is pending.
  * Prevented overlapping cleanup summaries during this transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->