### PR TITLE
fix: stop launch freeze from undrained subprocess pipes

### DIFF
--- a/PurgeTests/FolderSizingConcurrencyTests.swift
+++ b/PurgeTests/FolderSizingConcurrencyTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import Purge
+
+/// `CacheScanner.runSizeJobs` fans out to `maxConcurrent = 10` Swift tasks, each calling
+/// `FolderSizing.directorySizesForChunk` synchronously. On a 10-core machine that is exactly the
+/// width of the cooperative thread pool, so every pool thread ends up inside `du`. Any sizing
+/// implementation that needs a *second* thread to finish deadlocks there — the scan sticks at
+/// "Scanning…" with zero items and never recovers. These tests run the real production function
+/// under that fan-out.
+@Suite("Folder sizing under scan fan-out")
+struct FolderSizingConcurrencyTests {
+    /// Matches `CacheScanner.runSizeJobs`.
+    private static let scanConcurrency = 10
+
+    private func makeTree(directories: Int, bytesEach: Int) throws -> (root: URL, paths: [URL]) {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("purge-sizing-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let payload = Data(repeating: 0x41, count: bytesEach)
+        var paths: [URL] = []
+        for index in 0..<directories {
+            let dir = root.appendingPathComponent("dir-\(index)", isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try payload.write(to: dir.appendingPathComponent("payload.bin"))
+            paths.append(dir)
+        }
+        return (root, paths)
+    }
+
+    @Test("Every directory is measured when the whole pool is inside du")
+    func measuresAllChunksUnderFanOut() async throws {
+        let perChunk = FolderSizing.duChunkSize
+        let chunkCount = Self.scanConcurrency * 2
+        let (root, paths) = try makeTree(directories: perChunk * chunkCount, bytesEach: 8 * 1024)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var chunks: [[URL]] = []
+        var index = 0
+        while index < paths.count {
+            chunks.append(Array(paths[index..<min(index + perChunk, paths.count)]))
+            index += perChunk
+        }
+
+        let merged = await withTaskGroup(
+            of: [String: Int64].self,
+            returning: [String: Int64].self
+        ) { group in
+            for chunk in chunks {
+                group.addTask { FolderSizing.directorySizesForChunk(chunk) }
+            }
+            return await group.reduce(into: [:]) { $0.merge($1) { current, _ in current } }
+        }
+
+        #expect(merged.count == paths.count, "measured \(merged.count) of \(paths.count) directories")
+        for path in paths {
+            let key = path.standardizedFileURL.path
+            #expect(merged[key] ?? 0 > 0, "no size for \(key)")
+        }
+    }
+
+    /// `du` prints one "Permission denied" line per unreadable directory. That output lands on
+    /// stderr, so a runner that leaves stderr undrained wedges the child on a full pipe once the
+    /// tree is broad enough — the same deadlock as stdout, just quieter.
+    @Test("Directories that cannot be read do not stall the chunk")
+    func toleratesUnreadableDirectories() async throws {
+        let (root, paths) = try makeTree(directories: 40, bytesEach: 4 * 1024)
+        defer {
+            for path in paths { try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path.path) }
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        // Make half the tree unreadable so du has plenty to complain about.
+        for path in paths.enumerated() where path.offset.isMultiple(of: 2) {
+            try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: path.element.path)
+        }
+
+        let sizes = FolderSizing.directorySizesForChunk(paths)
+
+        // The readable half must still come back; du's exit status is non-zero either way.
+        let readable = paths.enumerated().filter { !$0.offset.isMultiple(of: 2) }.map(\.element)
+        for path in readable {
+            #expect(sizes[path.standardizedFileURL.path] ?? 0 > 0, "lost \(path.lastPathComponent)")
+        }
+    }
+}

--- a/PurgeTests/ProcessRunnerTests.swift
+++ b/PurgeTests/ProcessRunnerTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Testing
+@testable import Purge
+
+/// These pin the freeze that shipped in 1.2.9: `simctl list devices --json` printed more than
+/// the 64 KB pipe buffer, the scanner called `waitUntilExit()` before reading, and the child
+/// blocked mid-write while the app blocked waiting for it to exit — on the main thread, so the
+/// whole app beach-balled at launch. Every case below hangs forever against that old code.
+@Suite("ProcessRunner")
+struct ProcessRunnerTests {
+    /// Comfortably past the 64 KB kernel pipe buffer that made the original deadlock possible.
+    private static let floodBytes = 512 * 1024
+
+    private func runShell(_ script: String, timeout: TimeInterval = 30) -> ProcessRunner.Output? {
+        ProcessRunner.run(executablePath: "/bin/sh", arguments: ["-c", script], timeout: timeout)
+    }
+
+    @Test("Output larger than the pipe buffer comes back whole")
+    func drainsLargeStdout() async throws {
+        let bytes = Self.floodBytes
+        let result = try #require(runShell("/usr/bin/head -c \(bytes) /dev/zero"))
+
+        #expect(!result.timedOut)
+        #expect(result.status == 0)
+        #expect(result.stdout.count == bytes)
+    }
+
+    /// The subtler half: a child can just as easily wedge on a full *stderr* buffer while the
+    /// parent reads stdout. `du` does exactly this — one "Permission denied" line per
+    /// unreadable directory — so both pipes have to drain concurrently.
+    @Test("A child flooding both pipes at once still completes")
+    func drainsBothPipesConcurrently() async throws {
+        let bytes = Self.floodBytes
+        let result = try #require(
+            runShell("/usr/bin/head -c \(bytes) /dev/zero; /usr/bin/head -c \(bytes) /dev/zero >&2")
+        )
+
+        #expect(!result.timedOut)
+        #expect(result.status == 0)
+        #expect(result.stdout.count == bytes)
+        #expect(result.stderr.count == bytes)
+    }
+
+    @Test("A child that never exits is killed at the timeout")
+    func killsHungChild() async throws {
+        let started = Date()
+        let result = try #require(runShell("/bin/sleep 600", timeout: 1))
+
+        #expect(result.timedOut)
+        #expect(!result.succeeded)
+        // Timeout plus the SIGTERM grace period, with room for a loaded CI machine.
+        #expect(Date().timeIntervalSince(started) < 15)
+    }
+
+    /// The reported freeze happened on a machine running a process throttler, and the second
+    /// spindump caught `simctl` suspended. SIGTERM only queues for a stopped process, so the
+    /// runner has to escalate to SIGKILL or the wait never ends.
+    @Test("A suspended child is still reaped")
+    func killsSuspendedChild() async throws {
+        let started = Date()
+        // Stops itself before writing anything, so no pipe ever reaches EOF.
+        let result = try #require(runShell("kill -STOP $$; /bin/echo done", timeout: 1))
+
+        #expect(result.timedOut)
+        #expect(Date().timeIntervalSince(started) < 15)
+    }
+
+    @Test("Exit status and stderr survive a failing command")
+    func reportsFailure() async throws {
+        let result = try #require(runShell("/bin/echo oops >&2; exit 3"))
+
+        #expect(!result.succeeded)
+        #expect(result.status == 3)
+        #expect(result.stderrText.trimmingCharacters(in: .whitespacesAndNewlines) == "oops")
+    }
+
+    @Test("A missing binary reports launch failure rather than trapping")
+    func missingBinaryReturnsNil() async throws {
+        let result = ProcessRunner.run(
+            executablePath: "/nonexistent/definitely-not-here",
+            arguments: [],
+            timeout: 5
+        )
+        #expect(result == nil)
+    }
+
+    /// A child inheriting the parent's stdin can block on input that never arrives.
+    @Test("Reading stdin gets EOF instead of hanging")
+    func stdinIsNullDevice() async throws {
+        let result = try #require(runShell("/bin/cat", timeout: 5))
+
+        #expect(!result.timedOut)
+        #expect(result.status == 0)
+        #expect(result.stdout.isEmpty)
+    }
+
+    /// The second freeze, caused by the first fix: draining on two helper queues meant every
+    /// `run` blocked its thread waiting for work that needed *more* threads. Callers like
+    /// `CacheScanner.runSizeJobs` invoke this straight from Swift concurrency tasks, so those
+    /// blocked threads were the cooperative pool — only as wide as the core count. Saturate it
+    /// and the helper reads never got scheduled. This hangs against that version.
+    @Test("Saturating the cooperative pool still completes every child")
+    func survivesCooperativePoolSaturation() async throws {
+        let jobs = max(ProcessInfo.processInfo.activeProcessorCount * 3, 24)
+        let bytes = 256 * 1024
+
+        let results = await withTaskGroup(of: Int?.self, returning: [Int?].self) { group in
+            for _ in 0..<jobs {
+                group.addTask {
+                    // Deliberately the blocking entry point, called from a Swift task, floods
+                    // both pipes — exactly the shape of a `du` chunk under CacheScanner.
+                    ProcessRunner.run(
+                        executablePath: "/bin/sh",
+                        arguments: ["-c", "/usr/bin/head -c \(bytes) /dev/zero; /usr/bin/head -c \(bytes) /dev/zero >&2"],
+                        timeout: 60
+                    )?.stdout.count
+                }
+            }
+            return await group.reduce(into: []) { $0.append($1) }
+        }
+
+        #expect(results.count == jobs)
+        #expect(results.allSatisfy { $0 == bytes }, "some children did not drain: \(results)")
+    }
+
+    @Test("runAsync leaves the main actor free while the child runs")
+    @MainActor
+    func asyncVariantDoesNotBlockMainActor() async throws {
+        // Fails the debug precondition in `run` if the wait happens on the main queue, and
+        // deadlocks the flag below if `runAsync` blocks the main actor instead of suspending.
+        var mainActorRanDuringChild = false
+        async let child = ProcessRunner.runAsync(
+            executablePath: "/bin/sleep",
+            arguments: ["1"],
+            timeout: 10
+        )
+
+        await Task.yield()
+        mainActorRanDuringChild = true
+
+        let result = try #require(await child)
+        #expect(!result.timedOut)
+        #expect(mainActorRanDuringChild)
+    }
+}

--- a/purge/Services/DevScanner.swift
+++ b/purge/Services/DevScanner.swift
@@ -210,26 +210,19 @@ final class DevScanner {
 
     private static let xcrunPath = "/usr/bin/xcrun"
 
+    /// CoreSimulator can take a while to answer on a cold first call; past this the plist
+    /// fallback is a better answer than a stalled scan.
+    private static let simctlListTimeout: TimeInterval = 30
+
     private func loadSimulatorsFromSimctl(devicesRoot: URL) async -> [SimulatorDevice]? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: Self.xcrunPath)
-        process.arguments = ["simctl", "list", "devices", "--json"]
+        let result = await ProcessRunner.runAsync(
+            executablePath: Self.xcrunPath,
+            arguments: ["simctl", "list", "devices", "--json"],
+            timeout: Self.simctlListTimeout
+        )
+        guard let result, result.succeeded else { return nil }
 
-        let outPipe = Pipe()
-        let errPipe = Pipe()
-        process.standardOutput = outPipe
-        process.standardError = errPipe
-
-        do {
-            try process.run()
-        } catch {
-            return nil
-        }
-
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else { return nil }
-
-        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let data = result.stdout
         guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let devicesMap = root["devices"] as? [String: Any] else {
             return nil

--- a/purge/Services/FileDeleter.swift
+++ b/purge/Services/FileDeleter.swift
@@ -298,30 +298,30 @@ nonisolated final class FileDeleter: Sendable {
         case failure(String)
     }
 
+    /// Deleting a large device is real disk work, so this is generous — but still bounded, so a
+    /// wedged CoreSimulator cannot leave the delete run hanging forever.
+    private static let simctlDeleteTimeout: TimeInterval = 120
+
     private static func deleteCoreSimulatorDevice(udid: String) -> SimctlDeleteResult {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
-        process.arguments = ["simctl", "delete", udid]
-
-        let errPipe = Pipe()
-        process.standardError = errPipe
-        process.standardOutput = Pipe()
-
-        do {
-            try process.run()
-        } catch {
-            return .failure(error.localizedDescription)
+        guard let result = ProcessRunner.run(
+            executablePath: "/usr/bin/xcrun",
+            arguments: ["simctl", "delete", udid],
+            timeout: simctlDeleteTimeout
+        ) else {
+            return .failure("Could not launch xcrun")
         }
-        process.waitUntilExit()
-        if process.terminationStatus == 0 {
+
+        if result.timedOut {
+            return .failure("simctl delete timed out after \(Int(simctlDeleteTimeout))s")
+        }
+        if result.status == 0 {
             return .success
         }
-        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
-        let errText = String(data: errData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let errText, !errText.isEmpty {
+        let errText = result.stderrText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !errText.isEmpty {
             return .failure(errText)
         }
-        return .failure("simctl delete failed (exit \(process.terminationStatus))")
+        return .failure("simctl delete failed (exit \(result.status))")
     }
 
     /// Retries deletion for a single previously failed item.

--- a/purge/Services/GitStatusChecker.swift
+++ b/purge/Services/GitStatusChecker.swift
@@ -116,31 +116,21 @@ actor GitStatusChecker {
         }
     }
 
+    /// `git status` on a huge or network-mounted worktree can crawl; past this, "unknown" beats
+    /// holding the scan open.
+    private static let gitStatusTimeout: TimeInterval = 60
+
     /// Returns `.unknown` only if Git is unavailable; empty porcelain means `.clean`.
     private static func invokeGit(repository: URL) -> GitWorktreeStatus {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
-        process.arguments = ["-C", repository.path, "status", "--porcelain"]
-
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = Pipe()
-
-        do {
-            try process.run()
-        } catch {
+        guard let result = ProcessRunner.run(
+            executablePath: "/usr/bin/git",
+            arguments: ["-C", repository.path, "status", "--porcelain"],
+            timeout: gitStatusTimeout
+        ), result.succeeded else {
             return .unknown
         }
 
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-
-        guard process.terminationStatus == 0 else {
-            return .unknown
-        }
-
-        let output = String(data: data, encoding: .utf8) ?? ""
-        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = result.stdoutText.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? .clean : .dirty
     }
 }

--- a/purge/Utilities/FolderSizing.swift
+++ b/purge/Utilities/FolderSizing.swift
@@ -5,34 +5,35 @@ enum FolderSizing {
     static let duChunkSize = 64
     private static let maxConcurrentDuChunks = 10
 
+    /// A chunk walking a deep tree can legitimately take minutes, so this is loose. It exists
+    /// only so a `du` that never returns cannot wedge the scan permanently.
+    private static let duChunkTimeout: TimeInterval = 300
+
     nonisolated static func directorySizesForChunk(_ chunk: [URL]) -> [String: Int64] {
         guard !chunk.isEmpty else { return [:] }
 
-        var result: [String: Int64] = [:]
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/du")
-        process.arguments = ["-sk"] + chunk.map { $0.standardizedFileURL.path }
-
-        let outPipe = Pipe()
-        process.standardOutput = outPipe
-        process.standardError = Pipe()
-
-        do {
-            try process.run()
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-            process.waitUntilExit()
-
-            let output = String(data: data, encoding: .utf8) ?? ""
-            for line in output.split(separator: "\n") {
-                guard let tab = line.firstIndex(of: "\t") else { continue }
-                let kbStr = line[line.startIndex..<tab]
-                let path = String(line[line.index(after: tab)...])
-                if let kilobytes = Int64(kbStr) {
-                    result[path] = kilobytes * 1024
-                }
-            }
-        } catch {
+        // `du` writes one "Permission denied" line per unreadable directory, so stderr can run
+        // to megabytes on a broad scan. ProcessRunner drains it concurrently; leaving it
+        // undrained would block `du` on a full pipe and hang the read below.
+        guard let output = ProcessRunner.run(
+            executablePath: "/usr/bin/du",
+            arguments: ["-sk"] + chunk.map { $0.standardizedFileURL.path },
+            timeout: duChunkTimeout
+        ) else {
             // Omit paths in this chunk; callers default to 0.
+            return [:]
+        }
+
+        // Partial output from a timed-out or non-zero run is still worth keeping: `du` prints
+        // each total as it finishes, and a denied subpath makes it exit non-zero regardless.
+        var result: [String: Int64] = [:]
+        for line in output.stdoutText.split(separator: "\n") {
+            guard let tab = line.firstIndex(of: "\t") else { continue }
+            let kbStr = line[line.startIndex..<tab]
+            let path = String(line[line.index(after: tab)...])
+            if let kilobytes = Int64(kbStr) {
+                result[path] = kilobytes * 1024
+            }
         }
 
         return result

--- a/purge/Utilities/ProcessRunner.swift
+++ b/purge/Utilities/ProcessRunner.swift
@@ -1,0 +1,227 @@
+import Foundation
+
+/// Runs helper binaries (`xcrun`, `du`, `git`) without the three ways `Process` hangs an app.
+///
+/// **1. The pipe deadlock.** A child blocks once it fills the 64 KB kernel pipe buffer, so a
+/// parent that calls `waitUntilExit()` before draining can never make progress: the child cannot
+/// finish writing, the parent cannot stop waiting. `simctl list devices --json` clears 64 KB on
+/// any machine with a normal spread of runtimes, which froze Purge at launch for anyone with
+/// Xcode installed (1.2.9).
+///
+/// **2. The thread-pool deadlock.** Draining looks like a job for two helper queues, and that is
+/// the trap. Callers like `CacheScanner.runSizeJobs` invoke this from Swift concurrency tasks, so
+/// the blocking wait sits on a *cooperative pool* thread — and that pool is only as wide as the
+/// core count. Ten concurrent `du` chunks block all ten threads, the helper reads never get
+/// scheduled, and the app wedges with the scan stuck at zero. So both pipes are drained by
+/// `poll(2)` **on the calling thread**: no helper threads, no cross-queue dependency, nothing to
+/// starve.
+///
+/// **3. The unkillable child.** The wait is bounded and escalates SIGTERM → SIGKILL. SIGTERM only
+/// *queues* for a SIGSTOP'd process, so a child suspended by a throttler (App Tamer, in the
+/// original report) needs SIGKILL to be reaped at all.
+///
+/// This is `nonisolated` and blocking: call it off the main actor, and prefer ``runAsync`` from
+/// async code.
+nonisolated enum ProcessRunner {
+    struct Output: Sendable {
+        let status: Int32
+        let stdout: Data
+        let stderr: Data
+        /// `true` when the child overran its budget and was killed; `status` is then meaningless.
+        let timedOut: Bool
+
+        var succeeded: Bool { !timedOut && status == 0 }
+
+        var stdoutText: String { String(data: stdout, encoding: .utf8) ?? "" }
+        var stderrText: String { String(data: stderr, encoding: .utf8) ?? "" }
+    }
+
+    /// Grace period allowed after each escalation step once a child has overrun its timeout.
+    private static let terminationGrace: TimeInterval = 2
+
+    /// Upper bound on a single `poll` wait, so the deadline is still noticed on a silent child.
+    private static let pollSliceMilliseconds: Int32 = 250
+
+    private static let readBufferSize = 64 * 1024
+
+    /// Returns `nil` only when the binary could not be launched at all.
+    ///
+    /// Blocks the calling thread for up to `timeout`. The debug precondition is the guardrail
+    /// against reintroducing the launch freeze: this must never run on the main queue.
+    static func run(
+        executablePath: String,
+        arguments: [String],
+        timeout: TimeInterval
+    ) -> Output? {
+        #if DEBUG
+        dispatchPrecondition(condition: .notOnQueue(.main))
+        #endif
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+        // Without this a child that reads stdin inherits ours and waits on input that never comes.
+        process.standardInput = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        return withExtendedLifetime((outPipe, errPipe)) {
+            let stdoutFD = outPipe.fileHandleForReading.fileDescriptor
+            let stderrFD = errPipe.fileHandleForReading.fileDescriptor
+            // Required: `drainReadable` keeps reading until EAGAIN, which a blocking descriptor
+            // never reports — it would sit in `read` instead, defeating the point of polling.
+            // Only the parent's read ends are affected; the child's write ends are separate.
+            makeNonBlocking(stdoutFD)
+            makeNonBlocking(stderrFD)
+
+            let drain = drainPipes(
+                process: process,
+                stdoutFD: stdoutFD,
+                stderrFD: stderrFD,
+                timeout: timeout
+            )
+
+            guard drain.reachedEOF else {
+                // Both pipes still open past SIGKILL — a surviving grandchild is holding them.
+                // Abandon rather than hand the caller an unbounded wait.
+                return Output(status: -1, stdout: drain.stdout, stderr: drain.stderr, timedOut: true)
+            }
+
+            process.waitUntilExit()
+            return Output(
+                status: process.terminationStatus,
+                stdout: drain.stdout,
+                stderr: drain.stderr,
+                timedOut: drain.timedOut
+            )
+        }
+    }
+
+    private static func makeNonBlocking(_ fd: Int32) {
+        let flags = fcntl(fd, F_GETFL, 0)
+        guard flags >= 0 else { return }
+        _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+    }
+
+    private struct DrainResult {
+        var stdout = Data()
+        var stderr = Data()
+        var timedOut = false
+        /// `false` when we gave up with a pipe still open, which makes `waitUntilExit` unsafe.
+        var reachedEOF = false
+    }
+
+    /// Reads both descriptors until EOF on the calling thread, escalating signals past `timeout`.
+    private static func drainPipes(
+        process: Process,
+        stdoutFD: Int32,
+        stderrFD: Int32,
+        timeout: TimeInterval
+    ) -> DrainResult {
+        var result = DrainResult()
+        var openOut = true
+        var openErr = true
+        var deadline = Date().addingTimeInterval(timeout)
+        var sentTerm = false
+        var sentKill = false
+        var buffer = [UInt8](repeating: 0, count: readBufferSize)
+
+        while openOut || openErr {
+            if Date() >= deadline {
+                result.timedOut = true
+                if !sentTerm {
+                    sentTerm = true
+                    process.terminate()
+                } else if !sentKill {
+                    sentKill = true
+                    // SIGTERM is only queued for a stopped process; SIGKILL always lands.
+                    kill(process.processIdentifier, SIGKILL)
+                } else {
+                    return result
+                }
+                deadline = Date().addingTimeInterval(terminationGrace)
+                continue
+            }
+
+            var pollFDs: [pollfd] = []
+            if openOut { pollFDs.append(pollfd(fd: stdoutFD, events: Int16(POLLIN), revents: 0)) }
+            if openErr { pollFDs.append(pollfd(fd: stderrFD, events: Int16(POLLIN), revents: 0)) }
+
+            let ready = poll(&pollFDs, nfds_t(pollFDs.count), pollSliceMilliseconds)
+            if ready < 0 {
+                if errno == EINTR { continue }
+                return result
+            }
+            if ready == 0 { continue }
+
+            for entry in pollFDs where entry.revents != 0 {
+                // POLLHUP can arrive with data still buffered, so always read to EOF or EAGAIN
+                // rather than trusting the flag.
+                let hitEOF = drainReadable(fd: entry.fd, into: &buffer) { bytes in
+                    guard let base = bytes.baseAddress else { return }
+                    if entry.fd == stdoutFD {
+                        result.stdout.append(base, count: bytes.count)
+                    } else {
+                        result.stderr.append(base, count: bytes.count)
+                    }
+                }
+                if hitEOF {
+                    if entry.fd == stdoutFD { openOut = false } else { openErr = false }
+                }
+            }
+        }
+
+        result.reachedEOF = true
+        return result
+    }
+
+    /// Reads everything currently available on `fd`. Returns `true` once the descriptor is done.
+    private static func drainReadable(
+        fd: Int32,
+        into buffer: inout [UInt8],
+        append: (UnsafeMutableBufferPointer<UInt8>) -> Void
+    ) -> Bool {
+        while true {
+            let count = buffer.withUnsafeMutableBytes { raw in
+                read(fd, raw.baseAddress, raw.count)
+            }
+            if count > 0 {
+                buffer.withUnsafeMutableBufferPointer { pointer in
+                    append(UnsafeMutableBufferPointer(rebasing: pointer[0..<count]))
+                }
+                continue
+            }
+            if count == 0 { return true }
+            switch errno {
+            case EINTR: continue
+            case EAGAIN: return false
+            default: return true
+            }
+        }
+    }
+
+    /// Async wrapper that keeps the blocking drain off whatever actor or cooperative thread the
+    /// caller is running on.
+    static func runAsync(
+        executablePath: String,
+        arguments: [String],
+        timeout: TimeInterval
+    ) async -> Output? {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                continuation.resume(
+                    returning: run(executablePath: executablePath, arguments: arguments, timeout: timeout)
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes the instant beach ball on launch reported against 1.2.9 by a user who installed from Reddit, gave all permissions, and enabled login-at-startup.

## The bug

Two spindumps pin it exactly. Purge's **main thread**:

```
_dispatch_main_queue_drain → swift_job_run → Purge → -[NSConcreteTask waitUntilExit]
```

Its **child, `simctl`** (`Parent: Purge [6602]`):

```
dprintf → _vdprintf → __sfvwrite → _swrite → __write_nocancel → blocked in kernel
```

`DevScanner` ran `xcrun simctl list devices --json`, then called `waitUntilExit()` **before** reading the pipe. Once `simctl`'s output crosses the 64 KB kernel pipe buffer it blocks mid-write and can never exit; Purge blocks waiting for it to exit and never drains. Neither side can move.

Two things made it fatal rather than slow:

- `DevScanner` is an unannotated class, so under `SWIFT_DEFAULT_ACTOR_ISOLATION=MainActor` the blocking wait ran **on the main thread** — instant beach ball, not a stalled background scan. The `Task.detached` in `runDeveloperScan` hops right back to the main actor on `await self.…`.
- No timeout. The reporter's app hung for 1,089 seconds until force-quit.

It reproduces at every launch for anyone with enough Xcode runtimes installed. The reporter also runs App Tamer, and the second spindump caught `simctl` suspended — which wedges it even below 64 KB.

## The fix

New `ProcessRunner` drains stdout and stderr with `poll(2)` **on the calling thread**, and bounds the wait with SIGTERM → SIGKILL escalation. SIGTERM only *queues* for a SIGSTOP'd process, so a child suspended by a throttler needs SIGKILL to be reaped at all.

### Why poll and not helper queues

This is the part worth reviewing. Draining on two helper queues is the obvious shape, and it deadlocks a different way — I shipped that version into a local build and it hung:

```
11 × ProcessRunner.run → dispatch_group_wait   (blocked)
 0 × readDataToEndOfFile                        (never scheduled)
```

All eleven were on `com.apple.root.user-initiated-qos.cooperative`. `CacheScanner.runSizeJobs` fans out to `maxConcurrent = 10` Swift tasks that call `FolderSizing.directorySizesForChunk` **synchronously**, which on a 10-core machine is the entire cooperative pool width. Every pool thread blocks inside the drain, the helper reads never get a thread, and the scan pins at "Scanning… 0 items" forever — UI responsive, nothing happening.

`poll` on the calling thread has no cross-queue dependency, so there is nothing left to starve. Please don't reintroduce a helper thread into that path; the doc comment on `ProcessRunner` explains why, and a DEBUG `dispatchPrecondition(.notOnQueue(.main))` guards the other half.

### Also fixed

`FolderSizing` and `GitStatusChecker` read stdout in the right order but left **stderr** undrained — same hazard, since `du` prints one "Permission denied" line per unreadable directory and can fill that pipe on a broad scan. Both now go through `ProcessRunner`.

Every call site gained a bounded timeout: `simctl list` 30s (falls back to the plist path), `simctl delete` 120s, `du` chunk 300s, `git status` 60s.

## Verification

Tests were checked against the **broken** implementations, not just the fixed one, so they are real regression tests:

| Test | Broken design | Fixed |
|---|---|---|
| `measuresAllChunksUnderFanOut` (20 chunks × 64 real dirs) | **601s — hung** | 0.675s |
| `survivesCooperativePoolSaturation` | **failed** | 0.334s |
| rest of `ProcessRunnerTests` | gridlocked at 180s | pass |

- Full suite: **223 passed, 1 failed** — `cacheSafetyStillBlocksPersonalMediaPaths`, which already fails on clean `main`.
- Real `simctl` discovery path returns 13 simulators in 0.15s, exactly matching `xcrun simctl`'s own count — parsing is unchanged.

## Out of scope

Version is still 1.2.9 (14) — no bump included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved reliability when scanning simulators, checking Git status, measuring folders, and deleting simulator data.
  * Added timeouts and safer handling for stalled, unavailable, or failed system commands.
  * Preserved useful output and error details when operations partially complete or encounter issues.
  * Reduced the risk of application hangs during large output processing and concurrent folder scans.

* **Tests**
  * Added coverage for command timeouts, interrupted processes, permission issues, large output, and concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->