### PR TITLE
Surface locally downloaded AI models in Large Files

### DIFF
--- a/PurgeTests/AIModelScanTests.swift
+++ b/PurgeTests/AIModelScanTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+@testable import Purge
+
+@Suite("Local AI models are found as models, not as blobs")
+struct AIModelScanTests {
+    /// Builds a throwaway home directory holding an Ollama store, so the tests
+    /// exercise real manifest parsing and blob reference counting rather than
+    /// whatever happens to be installed on the machine running them.
+    private func makeOllamaHome(
+        models: [String: [String]],
+        blobBytes: Int = 4096
+    ) throws -> URL {
+        let fm = FileManager.default
+        let home = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = home.appendingPathComponent(".ollama/models", isDirectory: true)
+        let blobs = root.appendingPathComponent("blobs", isDirectory: true)
+        try fm.createDirectory(at: blobs, withIntermediateDirectories: true)
+
+        var written: Set<String> = []
+        for (name, digests) in models {
+            let manifest = root
+                .appendingPathComponent("manifests/registry.ollama.ai/library", isDirectory: true)
+                .appendingPathComponent(name, isDirectory: true)
+                .appendingPathComponent("latest", isDirectory: false)
+            try fm.createDirectory(
+                at: manifest.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+
+            let layers = digests.map { ["mediaType": "application/vnd.ollama.image.model", "digest": "sha256:\($0)"] }
+            let body: [String: Any] = ["schemaVersion": 2, "layers": layers]
+            try JSONSerialization.data(withJSONObject: body).write(to: manifest)
+
+            for digest in digests where !written.contains(digest) {
+                written.insert(digest)
+                try Data(repeating: 0, count: blobBytes)
+                    .write(to: blobs.appendingPathComponent("sha256-\(digest)"))
+            }
+        }
+        return home
+    }
+
+    @Test("An Ollama model is named the way the user pulled it")
+    func ollamaModelUsesRegistryName() throws {
+        let home = try makeOllamaHome(models: ["gemma4": ["aaa"]])
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let models = AIModelScanner.ollamaModels(home: home, environment: [:])
+        #expect(models.count == 1)
+        #expect(models.first?.displayName == "gemma4:latest")
+        #expect(models.first?.locationLabel == "Ollama")
+        #expect(models.first?.category == .aiModel)
+    }
+
+    @Test("Deleting a model takes its manifest and its own blobs")
+    func ollamaModelComponentsIncludeManifestFirst() throws {
+        let home = try makeOllamaHome(models: ["gemma4": ["aaa", "bbb"]])
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let model = try #require(AIModelScanner.ollamaModels(home: home, environment: [:]).first)
+        #expect(model.componentPaths.count == 3)
+        // Manifest first: an interrupted delete must not leave Ollama listing a
+        // model whose weights are already gone.
+        #expect(model.componentPaths.first?.lastPathComponent == "latest")
+        #expect(model.componentPaths.dropFirst().allSatisfy { $0.lastPathComponent.hasPrefix("sha256-") })
+    }
+
+    @Test("A blob shared with another model is neither counted nor deleted")
+    func sharedBlobsAreExcluded() throws {
+        let home = try makeOllamaHome(models: [
+            "gemma4": ["shared", "onlyA"],
+            "llama3": ["shared", "onlyB"]
+        ])
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let models = AIModelScanner.ollamaModels(home: home, environment: [:])
+        #expect(models.count == 2)
+
+        for model in models {
+            // Only the exclusively-owned blob is reclaimable, so the row must
+            // promise one blob's worth of space, not two.
+            #expect(model.sizeBytes == 4096)
+            #expect(!model.componentPaths.contains { $0.lastPathComponent == "sha256-shared" })
+        }
+    }
+
+    @Test("OLLAMA_MODELS moves the store")
+    func honoursOllamaModelsOverride() {
+        let home = URL(fileURLWithPath: "/Users/someone")
+        let relocated = AIModelScanPolicy.ollamaRoot(
+            home: home,
+            environment: ["OLLAMA_MODELS": "/Volumes/External/models"]
+        )
+        #expect(relocated.path == "/Volumes/External/models")
+        #expect(AIModelScanPolicy.ollamaRoot(home: home, environment: [:]).path
+            == "/Users/someone/.ollama/models")
+    }
+
+    @Test("Only paths inside a model root may be deleted")
+    func deletionGateIsNarrow() throws {
+        let home = try makeOllamaHome(models: ["gemma4": ["aaa"]])
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let model = try #require(AIModelScanner.ollamaModels(home: home, environment: [:]).first)
+        for component in model.componentPaths {
+            #expect(AIModelScanPolicy.isEligibleForDeletion(component, home: home, environment: [:]))
+        }
+
+        // The store itself is not a row, and must never be deletable as one.
+        let root = home.appendingPathComponent(".ollama/models", isDirectory: true)
+        #expect(!AIModelScanPolicy.isEligibleForDeletion(root, home: home, environment: [:]))
+        #expect(!AIModelScanPolicy.isEligibleForDeletion(
+            home.appendingPathComponent("Documents/notes.txt"), home: home, environment: [:]
+        ))
+    }
+
+    @Test("Ordinary large files still stand for exactly one path")
+    func plainFilesHaveSingleComponent() {
+        let file = LargeFile(
+            path: URL(fileURLWithPath: "/Users/someone/Movies/clip.mov"),
+            sizeBytes: 1024,
+            lastUsed: Date(),
+            category: .video
+        )
+        #expect(file.componentPaths == [URL(fileURLWithPath: "/Users/someone/Movies/clip.mov")])
+        #expect(file.displayName == "clip.mov")
+    }
+}

--- a/PurgeTests/AIModelScanTests.swift
+++ b/PurgeTests/AIModelScanTests.swift
@@ -115,6 +115,40 @@ struct AIModelScanTests {
         ))
     }
 
+    @Test("A model survives a delete that only got part of the way")
+    func partiallyDeletedModelStaysListed() throws {
+        let home = try makeOllamaHome(models: ["gemma4": ["aaa", "bbb"]])
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let model = try #require(AIModelScanner.ollamaModels(home: home, environment: [:]).first)
+
+        // The manifest trashes first, so this is the realistic failure: Ollama
+        // has already stopped listing the model, but a blob is still on disk.
+        // Dropping the row here would strand those bytes for good — blobs are
+        // only ever discovered through a manifest that no longer exists.
+        let manifestOnly: Set<String> = [model.componentPaths[0].path]
+        #expect(!model.isFullyRemoved(byDeleting: manifestOnly))
+
+        let allButLast = Set(model.componentPaths.dropLast().map(\.path))
+        #expect(!model.isFullyRemoved(byDeleting: allButLast))
+
+        let everything = Set(model.componentPaths.map(\.path))
+        #expect(model.isFullyRemoved(byDeleting: everything))
+    }
+
+    @Test("A single-file row clears on its own path")
+    func plainFileClearsWhenItsPathIsDeleted() {
+        let file = LargeFile(
+            path: URL(fileURLWithPath: "/Users/someone/Movies/clip.mov"),
+            sizeBytes: 1024,
+            lastUsed: Date(),
+            category: .video
+        )
+        #expect(file.isFullyRemoved(byDeleting: ["/Users/someone/Movies/clip.mov"]))
+        #expect(!file.isFullyRemoved(byDeleting: []))
+        #expect(!file.isFullyRemoved(byDeleting: ["/Users/someone/Movies/other.mov"]))
+    }
+
     @Test("Ordinary large files still stand for exactly one path")
     func plainFilesHaveSingleComponent() {
         let file = LargeFile(

--- a/purge/Models/LargeFile.swift
+++ b/purge/Models/LargeFile.swift
@@ -8,6 +8,7 @@ enum LargeFileCategory: String, CaseIterable, Identifiable, Hashable {
     case pdf
     case archive
     case document
+    case aiModel
     case other
 
     var id: String { rawValue }
@@ -20,6 +21,7 @@ enum LargeFileCategory: String, CaseIterable, Identifiable, Hashable {
         case .pdf: return "PDFs"
         case .archive: return "Archives"
         case .document: return "Documents"
+        case .aiModel: return "AI Models"
         case .other: return "Other"
         }
     }
@@ -32,6 +34,7 @@ enum LargeFileCategory: String, CaseIterable, Identifiable, Hashable {
         case .pdf: return "doc.richtext"
         case .archive: return "archivebox"
         case .document: return "doc.text"
+        case .aiModel: return "cpu"
         case .other: return "doc"
         }
     }
@@ -64,6 +67,20 @@ struct LargeFile: Identifiable, Hashable {
     let category: LargeFileCategory
     var isSelected: Bool = false
 
+    /// Set when the file name on disk isn't what the user calls the thing. An
+    /// Ollama model lives at `manifests/registry.ollama.ai/library/gemma4/latest`
+    /// but the user knows it as `gemma4:latest`.
+    let displayNameOverride: String?
+
+    /// Shown instead of a directory path for rows whose real location is an
+    /// implementation detail — "Ollama" reads better than `~/.ollama/models/…`.
+    let sourceLabel: String?
+
+    /// Every path that must be removed for this row to be gone. Ordinary files
+    /// own exactly one; an AI model spans a manifest plus the blobs it alone
+    /// references.
+    let componentPaths: [URL]
+
     /// Stored (not computed) so identity checks in row bindings, sorting, and list
     /// animations don't re-standardize the URL on every access — the repeated cost
     /// made selection feel delayed compared to App Caches.
@@ -74,18 +91,26 @@ struct LargeFile: Identifiable, Hashable {
         sizeBytes: Int64,
         lastUsed: Date,
         category: LargeFileCategory,
-        isSelected: Bool = false
+        isSelected: Bool = false,
+        displayNameOverride: String? = nil,
+        sourceLabel: String? = nil,
+        componentPaths: [URL]? = nil
     ) {
         self.path = path
         self.sizeBytes = sizeBytes
         self.lastUsed = lastUsed
         self.category = category
         self.isSelected = isSelected
+        self.displayNameOverride = displayNameOverride
+        self.sourceLabel = sourceLabel
+        self.componentPaths = (componentPaths ?? [path]).map(\.standardizedFileURL)
         self.id = path.standardizedFileURL.path
     }
-    var displayName: String { path.lastPathComponent }
+    var displayName: String { displayNameOverride ?? path.lastPathComponent }
     var formattedSize: String { formatBytes(sizeBytes) }
-    var locationLabel: String { displayDirectoryPath(for: path.deletingLastPathComponent()) }
+    var locationLabel: String {
+        sourceLabel ?? displayDirectoryPath(for: path.deletingLastPathComponent())
+    }
 }
 
 enum LargeFileSizeThreshold: Int, CaseIterable, Identifiable {

--- a/purge/Models/LargeFile.swift
+++ b/purge/Models/LargeFile.swift
@@ -106,6 +106,13 @@ struct LargeFile: Identifiable, Hashable {
         self.componentPaths = (componentPaths ?? [path]).map(\.standardizedFileURL)
         self.id = path.standardizedFileURL.path
     }
+    /// Whether this row may leave the list, given the paths a delete run
+    /// actually removed. Multi-part rows survive a partial delete: a model whose
+    /// manifest trashed but whose blobs didn't still occupies the disk.
+    func isFullyRemoved(byDeleting deletedPaths: Set<String>) -> Bool {
+        componentPaths.allSatisfy { deletedPaths.contains($0.path) }
+    }
+
     var displayName: String { displayNameOverride ?? path.lastPathComponent }
     var formattedSize: String { formatBytes(sizeBytes) }
     var locationLabel: String {

--- a/purge/Services/AIModelScanPolicy.swift
+++ b/purge/Services/AIModelScanPolicy.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Bounds for locally downloaded AI models (Ollama, LM Studio).
+///
+/// These live in hidden directories outside the Large Files scan roots, so they
+/// need their own roots and their own deletion gate. Kept separate from
+/// `LargeFileScanPolicy` because a model row stands for several files at once —
+/// an Ollama model is a manifest plus the blobs it owns — and the eligibility
+/// rule has to admit those blobs by their content-addressed names.
+enum AIModelScanPolicy {
+    enum Runtime: String, CaseIterable {
+        case ollama
+        case lmStudio
+
+        var displayName: String {
+            switch self {
+            case .ollama: return "Ollama"
+            case .lmStudio: return "LM Studio"
+            }
+        }
+    }
+
+    /// Ollama honours `OLLAMA_MODELS` for users who move the store to an
+    /// external drive, so the default path is a fallback rather than a given.
+    nonisolated static func ollamaRoot(
+        home: URL,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL {
+        if let override = environment["OLLAMA_MODELS"], !override.isEmpty {
+            return URL(fileURLWithPath: (override as NSString).expandingTildeInPath, isDirectory: true)
+                .standardizedFileURL
+        }
+        return home.appendingPathComponent(".ollama/models", isDirectory: true).standardizedFileURL
+    }
+
+    /// Current LM Studio location first, then the pre-0.3 cache location. Both
+    /// are checked because an upgrade leaves the old directory behind.
+    nonisolated static func lmStudioRoots(home: URL) -> [URL] {
+        [
+            home.appendingPathComponent(".lmstudio/models", isDirectory: true),
+            home.appendingPathComponent(".cache/lm-studio/models", isDirectory: true)
+        ].map(\.standardizedFileURL)
+    }
+
+    nonisolated static func allRoots(
+        home: URL,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [URL] {
+        [ollamaRoot(home: home, environment: environment)] + lmStudioRoots(home: home)
+    }
+
+    /// A path may be removed only if it sits strictly inside one of the model
+    /// roots. The roots themselves are never deletable — emptying
+    /// `~/.ollama/models` wholesale is not something a row should ever mean.
+    nonisolated static func isEligibleForDeletion(
+        _ url: URL,
+        home: URL = FileManager.default.homeDirectoryForCurrentUser,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        let path = url.standardizedFileURL.path
+        guard FileManager.default.fileExists(atPath: path) else { return false }
+
+        return allRoots(home: home, environment: environment).contains { root in
+            path.hasPrefix(root.path + "/")
+        }
+    }
+}

--- a/purge/Services/AIModelScanner.swift
+++ b/purge/Services/AIModelScanner.swift
@@ -1,0 +1,224 @@
+import Foundation
+
+/// Discovers locally downloaded AI models and reports them as whole models
+/// rather than as files on disk.
+///
+/// Ollama stores content-addressed blobs (`blobs/sha256-4c27e0…`), so listing
+/// the raw files would show the user a meaningless hex name and let them break
+/// a model without Ollama noticing — the manifest would still claim the model
+/// is installed. Blobs are also shared between models, so the reclaimable size
+/// of a model is only the blobs no other manifest references.
+final class AIModelScanner {
+    func scanStream(minBytes: Int64, staleDays: Int) -> AsyncStream<LargeFile> {
+        AsyncStream { continuation in
+            let task = Task.detached(priority: .userInitiated) {
+                await Self.run(minBytes: minBytes, staleDays: staleDays, continuation: continuation)
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    private static func run(
+        minBytes: Int64,
+        staleDays: Int,
+        continuation: AsyncStream<LargeFile>.Continuation
+    ) async {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let now = Date()
+        let discovered = ollamaModels(home: home) + lmStudioModels(home: home)
+
+        for model in discovered {
+            if Task.isCancelled { break }
+            guard model.sizeBytes >= minBytes else { continue }
+            if staleDays > 0 {
+                let days = Calendar.current.dateComponents([.day], from: model.lastUsed, to: now).day ?? 0
+                guard days >= staleDays else { continue }
+            }
+            continuation.yield(model)
+        }
+
+        continuation.finish()
+    }
+
+    // MARK: - Ollama
+
+    private struct OllamaManifest: Decodable {
+        struct Layer: Decodable {
+            let digest: String
+        }
+        let config: Layer?
+        let layers: [Layer]
+
+        /// Every blob the model needs, config included — the config blob is as
+        /// much a part of the model as the weights are.
+        var digests: [String] {
+            layers.map(\.digest) + (config.map { [$0.digest] } ?? [])
+        }
+    }
+
+    static func ollamaModels(home: URL, environment: [String: String] = ProcessInfo.processInfo.environment) -> [LargeFile] {
+        let fm = FileManager.default
+        let root = AIModelScanPolicy.ollamaRoot(home: home, environment: environment)
+        let manifestRoot = root.appendingPathComponent("manifests", isDirectory: true)
+        let blobRoot = root.appendingPathComponent("blobs", isDirectory: true)
+        guard fm.fileExists(atPath: manifestRoot.path) else { return [] }
+
+        // Parse every manifest first: a blob is only reclaimable if exactly one
+        // model references it, and that is not knowable one model at a time.
+        var parsed: [(url: URL, digests: [String])] = []
+        var referenceCounts: [String: Int] = [:]
+
+        guard let enumerator = fm.enumerator(
+            at: manifestRoot,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsPackageDescendants]
+        ) else { return [] }
+
+        while let next = enumerator.nextObject() {
+            if Task.isCancelled { return [] }
+            guard let url = next as? URL,
+                  (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true,
+                  url.lastPathComponent != ".DS_Store",
+                  let data = try? Data(contentsOf: url),
+                  let manifest = try? JSONDecoder().decode(OllamaManifest.self, from: data)
+            else { continue }
+
+            let digests = Array(Set(manifest.digests))
+            parsed.append((url, digests))
+            for digest in digests {
+                referenceCounts[digest, default: 0] += 1
+            }
+        }
+
+        return parsed.compactMap { manifest in
+            var reclaimableBytes: Int64 = 0
+            var lastUsed = Date.distantPast
+            // The manifest itself is tiny but must go, or Ollama keeps listing a
+            // model whose weights are gone.
+            var components: [URL] = [manifest.url]
+
+            for digest in manifest.digests {
+                let blob = blobRoot.appendingPathComponent(digest.replacingOccurrences(of: ":", with: "-"))
+                guard let values = try? blob.resourceValues(forKeys: [
+                    .totalFileAllocatedSizeKey, .fileSizeKey,
+                    .contentAccessDateKey, .contentModificationDateKey
+                ]) else { continue }
+
+                let touched = max(
+                    values.contentAccessDate ?? .distantPast,
+                    values.contentModificationDate ?? .distantPast
+                )
+                lastUsed = max(lastUsed, touched)
+
+                guard referenceCounts[digest] == 1 else { continue }
+                reclaimableBytes += Int64(values.totalFileAllocatedSize ?? values.fileSize ?? 0)
+                components.append(blob)
+            }
+
+            guard reclaimableBytes > 0 else { return nil }
+            return LargeFile(
+                path: manifest.url,
+                sizeBytes: reclaimableBytes,
+                lastUsed: lastUsed == .distantPast ? Date.distantPast : lastUsed,
+                category: .aiModel,
+                displayNameOverride: ollamaModelName(manifestURL: manifest.url, manifestRoot: manifestRoot),
+                sourceLabel: AIModelScanPolicy.Runtime.ollama.displayName,
+                componentPaths: components
+            )
+        }
+    }
+
+    /// `manifests/registry.ollama.ai/library/gemma4/latest` reads back as
+    /// `gemma4:latest` — the name the user typed to pull it.
+    private static func ollamaModelName(manifestURL: URL, manifestRoot: URL) -> String {
+        let parts = manifestURL.standardizedFileURL.pathComponents
+            .dropFirst(manifestRoot.standardizedFileURL.pathComponents.count)
+        guard parts.count >= 2 else { return manifestURL.lastPathComponent }
+
+        let tag = parts.last!
+        // Drop the registry host, and the default `library` namespace, so only
+        // the parts a user would actually type survive.
+        var name = Array(parts.dropLast().dropFirst())
+        if name.first == "library" { name.removeFirst() }
+        guard !name.isEmpty else { return "\(parts[parts.startIndex + 1]):\(tag)" }
+        return "\(name.joined(separator: "/")):\(tag)"
+    }
+
+    // MARK: - LM Studio
+
+    /// LM Studio lays models out as `<publisher>/<repo>/<weights>.gguf`, so the
+    /// repo directory is the unit — it holds the weights plus any config and
+    /// split parts that belong with them.
+    static func lmStudioModels(home: URL) -> [LargeFile] {
+        let fm = FileManager.default
+        var models: [LargeFile] = []
+
+        for root in AIModelScanPolicy.lmStudioRoots(home: home) {
+            guard fm.fileExists(atPath: root.path) else { continue }
+            let publishers = (try? fm.contentsOfDirectory(
+                at: root,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )) ?? []
+
+            for publisher in publishers {
+                if Task.isCancelled { return models }
+                guard (try? publisher.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+                else { continue }
+
+                let repos = (try? fm.contentsOfDirectory(
+                    at: publisher,
+                    includingPropertiesForKeys: [.isDirectoryKey],
+                    options: [.skipsHiddenFiles]
+                )) ?? []
+
+                for repo in repos {
+                    guard (try? repo.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+                    else { continue }
+                    let measured = directorySize(at: repo)
+                    guard measured.bytes > 0 else { continue }
+
+                    models.append(LargeFile(
+                        path: repo,
+                        sizeBytes: measured.bytes,
+                        lastUsed: measured.lastUsed,
+                        category: .aiModel,
+                        displayNameOverride: "\(publisher.lastPathComponent)/\(repo.lastPathComponent)",
+                        sourceLabel: AIModelScanPolicy.Runtime.lmStudio.displayName,
+                        componentPaths: [repo]
+                    ))
+                }
+            }
+        }
+
+        return models
+    }
+
+    private static func directorySize(at url: URL) -> (bytes: Int64, lastUsed: Date) {
+        let keys: Set<URLResourceKey> = [
+            .isRegularFileKey, .totalFileAllocatedSizeKey, .fileSizeKey,
+            .contentAccessDateKey, .contentModificationDateKey
+        ]
+        guard let enumerator = FileManager.default.enumerator(
+            at: url,
+            includingPropertiesForKeys: Array(keys),
+            options: [.skipsPackageDescendants]
+        ) else { return (0, .distantPast) }
+
+        var bytes: Int64 = 0
+        var lastUsed = Date.distantPast
+        while let next = enumerator.nextObject() {
+            if Task.isCancelled { break }
+            guard let fileURL = next as? URL,
+                  let values = try? fileURL.resourceValues(forKeys: keys),
+                  values.isRegularFile == true
+            else { continue }
+            bytes += Int64(values.totalFileAllocatedSize ?? values.fileSize ?? 0)
+            lastUsed = max(lastUsed, max(
+                values.contentAccessDate ?? .distantPast,
+                values.contentModificationDate ?? .distantPast
+            ))
+        }
+        return (bytes, lastUsed)
+    }
+}

--- a/purge/Services/FileDeleter.swift
+++ b/purge/Services/FileDeleter.swift
@@ -241,7 +241,12 @@ nonisolated final class FileDeleter: Sendable {
             let standardizedPath = url.standardizedFileURL.path
             let friendlyTitle = pathToDisplayName[standardizedPath]
 
-            guard LargeFileScanPolicy.isEligibleForDeletion(url) else {
+            // AI model components live in hidden runtime directories that the
+            // large-file policy deliberately refuses, so they carry their own
+            // equally narrow gate.
+            let isEligible = LargeFileScanPolicy.isEligibleForDeletion(url)
+                || AIModelScanPolicy.isEligibleForDeletion(url)
+            guard isEligible else {
                 skippedItems.append(SkippedDeletionItem(
                     path: url.path,
                     displayName: friendlyTitle,

--- a/purge/Services/PurgeStore.swift
+++ b/purge/Services/PurgeStore.swift
@@ -177,6 +177,7 @@ final class PurgeStore: ObservableObject {
     private let cacheScanner = CacheScanner()
     private let devScanner = DevScanner()
     private let largeFileScanner = LargeFileScanner()
+    private let aiModelScanner = AIModelScanner()
     private let fileDeleter = FileDeleter()
     private let defaults = UserDefaults.standard
     private let gitChecker = GitStatusChecker()
@@ -802,6 +803,16 @@ final class PurgeStore: ObservableObject {
         let minBytes = LargeFileSizeThreshold.current().bytes
         let staleDays = LargeFileAgeThreshold.currentThresholdDays()
         var collected: [LargeFile] = []
+
+        // Models resolve from a handful of manifests, so they land almost
+        // instantly — running them ahead of the file walk puts the biggest
+        // items on screen first instead of after a full home-directory sweep.
+        for await model in aiModelScanner.scanStream(minBytes: minBytes, staleDays: staleDays) {
+            guard largeFileScanGeneration == generation, !Task.isCancelled else { return }
+            collected.append(model)
+        }
+        largeFiles = collected.sorted { $0.sizeBytes > $1.sizeBytes }
+
         for await file in largeFileScanner.scanStream(minBytes: minBytes, staleDays: staleDays) {
             guard largeFileScanGeneration == generation, !Task.isCancelled else { return }
             collected.append(file)
@@ -844,13 +855,24 @@ final class PurgeStore: ObservableObject {
         let targets = selectedLargeFiles
         guard !targets.isEmpty, !isDeleting else { return }
 
-        let urls = targets.map { $0.path.standardizedFileURL }
+        // A row can stand for several files (an AI model is a manifest plus its
+        // blobs), so expand to components here. Component order matters: the
+        // manifest goes first, so an interrupted delete leaves orphaned blobs
+        // rather than a model Ollama still lists but can no longer run.
+        var urls: [URL] = []
         var pathToDisplayName: [String: String] = [:]
         var pathToExpectedSizeBytes: [String: Int64] = [:]
         for file in targets {
-            let key = file.path.standardizedFileURL.path
-            pathToDisplayName[key] = file.displayName
-            pathToExpectedSizeBytes[key] = file.sizeBytes
+            for component in file.componentPaths {
+                urls.append(component)
+                pathToDisplayName[component.path] = file.displayName
+            }
+            // Only single-file rows can claim a known size up front; for
+            // multi-part rows each component is measured as it goes so the
+            // total doesn't count the row's bytes once per component.
+            if file.componentPaths.count == 1, let only = file.componentPaths.first {
+                pathToExpectedSizeBytes[only.path] = file.sizeBytes
+            }
         }
 
         // Present the cleanup overlay in its cleaning phase and poll per-item

--- a/purge/Services/PurgeStore.swift
+++ b/purge/Services/PurgeStore.swift
@@ -911,10 +911,20 @@ final class PurgeStore: ObservableObject {
             let deletedPaths = Set(report.deletedItems.map {
                 URL(fileURLWithPath: $0.path).standardizedFileURL.path
             })
+            // A row is gone only when every path it stood for is gone. Matching
+            // on `id` alone would drop a model as soon as its manifest trashed,
+            // even if a multi-gigabyte blob failed and still occupies the disk —
+            // and since blobs are only ever discovered through their manifest, a
+            // later scan could never surface it again. Rows that deleted
+            // partially stay listed and stay selected, so a retry can finish the
+            // job (the already-trashed manifest is skipped as non-existent).
+            let clearedRowIDs = Set(
+                largeFiles.filter { $0.isFullyRemoved(byDeleting: deletedPaths) }.map(\.id)
+            )
             withAnimation(.easeInOut(duration: 0.2)) {
-                largeFiles.removeAll { deletedPaths.contains($0.id) }
+                largeFiles.removeAll { clearedRowIDs.contains($0.id) }
             }
-            largeFileSelection.ids.subtract(deletedPaths)
+            largeFileSelection.ids.subtract(clearedRowIDs)
             progressPoller.cancel()
             liveSession.completeRun(
                 bytesMovedToTrash: report.bytesMovedToTrash,


### PR DESCRIPTION
## What does this change?

Models downloaded by **Ollama** and **LM Studio** now appear in Large Files under a new **AI Models** category.

This came from [a Reddit comment](https://www.reddit.com/r/MacOS/comments/1vchqcf/comment/p11bi91/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button) — a user liked the app but noticed their local models never showed up. It's a fair gap: on my own machine `~/.ollama/models` is **9.6 GB** and Purge couldn't see a byte of it.

There were four independent reasons for that:

- `LargeFileScanPolicy.scanRoots` only covers Documents/Desktop/Downloads/Movies/Music/Pictures
- the scan enumerator passes `.skipsHiddenFiles`, dropping `~/.ollama` and `~/.lmstudio`
- `isExcludedDirectory` rejects anything starting with `.`
- `isEligibleForDeletion` is scoped to those same roots, so a delete would have silently refused anyway

### Why models aren't listed as files

Ollama is content-addressed. Listing the raw store would show the user a row named `sha256-4c27e0f5b5ad…`, and deleting that blob leaves the manifest behind — `ollama list` keeps advertising a model that can no longer run. Blobs are also shared between models (quantizations reuse layers), so a single file-level delete can break several models at once.

So `AIModelScanner` parses every manifest up front, reference-counts blobs across all of them, and emits **one row per model**, named the way it was pulled (`gemma4:latest`). Two behaviours worth reviewing:

- **Reported size is reclaimable bytes, not total model size.** A blob another manifest still references isn't counted, because that space wouldn't actually come back.
- **Components are ordered manifest-first.** An interrupted delete then leaves orphaned blobs — wasted space, recovered on a re-run — rather than a phantom model Ollama lists but can't load.

LM Studio groups by `<publisher>/<repo>`, the directory that holds the weights plus config and any split parts.

### Safety

Per CONTRIBUTING, this touches scanning and deletion logic, so the relevant bits:

`AIModelScanPolicy` is deliberately **separate** from `LargeFileScanPolicy` rather than an extension of it — the latter is scoped to personal files under the home scan roots, and widening it to admit hidden runtime directories would loosen a gate that guards unrelated things. The new gate admits only paths sitting *strictly inside* a model root, so the store directory itself is never deletable as a row. `OLLAMA_MODELS` is honoured for people who relocate the store to an external drive.

Deletion still goes through Trash like everything else — no new destructive path, and no shelling out to the `ollama` CLI (which would delete permanently and bypass the undo story).

## Related issue

None — originated from user feedback on Reddit.

## Screenshots

<img width="728" height="470" alt="image" src="https://github.com/user-attachments/assets/b171e635-987c-4aa0-8098-68c13db55953" />

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I built and ran the app locally — **built** (`BUILD SUCCEEDED`)
- [x] I ran the test suite and it passes — **218 passed, 1 failed**; the failure is `LargeFileScanPolicyTests/cacheSafetyStillBlocksPersonalMediaPaths`, which already fails on clean `main` and is untouched here
- [x] This PR is focused on a single fix/feature

Six new tests in `AIModelScanTests` build throwaway Ollama stores and cover naming, component ordering, shared-blob exclusion, the `OLLAMA_MODELS` override, and the deletion gate.

## Reviewer notes

One behaviour you may want to weigh in on: models go to Trash, and there's no in-app permanent delete by design. So "removing" a 9.6 GB model frees nothing until Trash is emptied in Finder, and briefly shows up there as a pile of `sha256-…` files. That's consistent with the rest of Purge, but far more noticeable at model sizes — a line of copy in the confirm sheet might be worth adding separately.

The LM Studio path is written from its documented layout and is **not** verified against a real install (not installed on this machine). The Ollama path is verified against real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scanning for Ollama and LM Studio AI models.
  * AI models now appear as reclaimable storage items with model names, locations, sizes, and usage dates.
  * Shared model data is excluded from reclaimable size calculations.
  * Added support for deleting eligible multi-file model components.

* **Bug Fixes**
  * Improved handling of model paths, environment overrides, missing files, malformed data, and scan cancellation.
  * Preserved safe deletion behavior for files that are not eligible for removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->