### PR TITLE
feat: add search to Large Files

### DIFF
--- a/PurgeTests/LargeFileSearchTests.swift
+++ b/PurgeTests/LargeFileSearchTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import Purge
+
+@Suite("Large file search matches on name and location")
+struct LargeFileSearchTests {
+    private func file(
+        path: String,
+        displayNameOverride: String? = nil,
+        sourceLabel: String? = nil
+    ) -> LargeFile {
+        LargeFile(
+            path: URL(fileURLWithPath: path),
+            sizeBytes: 1_000_000,
+            lastUsed: Date(),
+            category: .video,
+            displayNameOverride: displayNameOverride,
+            sourceLabel: sourceLabel
+        )
+    }
+
+    @Test
+    func emptyQueryMatchesEverything() {
+        let subject = file(path: "/Users/someone/Movies/wedding.mov")
+        #expect(subject.matches(searchQuery: ""))
+    }
+
+    @Test
+    func whitespaceOnlyQueryMatchesEverything() {
+        let subject = file(path: "/Users/someone/Movies/wedding.mov")
+        #expect(subject.matches(searchQuery: "   "))
+    }
+
+    @Test
+    func matchesOnFilename() {
+        let subject = file(path: "/Users/someone/Movies/wedding.mov")
+        #expect(subject.matches(searchQuery: "wedding"))
+        #expect(subject.matches(searchQuery: "mov"))
+        #expect(!subject.matches(searchQuery: "birthday"))
+    }
+
+    @Test
+    func matchIsCaseInsensitive() {
+        let subject = file(path: "/Users/someone/Movies/Wedding.mov")
+        #expect(subject.matches(searchQuery: "wedding"))
+        #expect(subject.matches(searchQuery: "WEDDING"))
+    }
+
+    @Test
+    func matchIsDiacriticInsensitive() {
+        let subject = file(path: "/Users/someone/Documents/Résumé.pdf")
+        #expect(subject.matches(searchQuery: "resume"))
+    }
+
+    @Test
+    func matchesOnParentFolder() {
+        let subject = file(path: "/Users/someone/Downloads/archive.zip")
+        #expect(subject.matches(searchQuery: "Downloads"))
+    }
+
+    @Test
+    func allTermsMustMatchButOrderDoesNot() {
+        let subject = file(path: "/Users/someone/Movies/wedding-final-cut.mov")
+        #expect(subject.matches(searchQuery: "wedding cut"))
+        #expect(subject.matches(searchQuery: "cut wedding"))
+        #expect(!subject.matches(searchQuery: "wedding birthday"))
+    }
+
+    @Test
+    func termsMayMatchAcrossNameAndFolder() {
+        let subject = file(path: "/Users/someone/Downloads/wedding.mov")
+        #expect(subject.matches(searchQuery: "downloads wedding"))
+    }
+
+    /// The haystack joins its parts with a newline precisely so a query can't match
+    /// by straddling the boundary between the folder path and the filename.
+    @Test
+    func queryCannotMatchAcrossTheNameBoundary() {
+        let subject = file(path: "/Users/someone/Downloads/wedding.mov")
+        #expect(!subject.matches(searchQuery: "Downloadswedding"))
+    }
+
+    @Test
+    func matchesOnDisplayNameOverrideRatherThanPathComponent() {
+        let subject = file(
+            path: "/Users/someone/.ollama/models/manifests/registry.ollama.ai/library/gemma4/latest",
+            displayNameOverride: "gemma4:latest",
+            sourceLabel: "Ollama"
+        )
+        #expect(subject.matches(searchQuery: "gemma4:latest"))
+        #expect(subject.matches(searchQuery: "gemma"))
+    }
+
+    /// A labelled row shows "Ollama" but lives under `~/.ollama` — both the label the
+    /// user sees and the path they don't should find it.
+    @Test
+    func labelledRowMatchesOnBothLabelAndRealPath() {
+        let subject = file(
+            path: "/Users/someone/.ollama/models/manifests/registry.ollama.ai/library/gemma4/latest",
+            displayNameOverride: "gemma4:latest",
+            sourceLabel: "Ollama"
+        )
+        #expect(subject.matches(searchQuery: "Ollama"))
+        #expect(subject.matches(searchQuery: "registry.ollama.ai"))
+    }
+}

--- a/purge/ContentView.swift
+++ b/purge/ContentView.swift
@@ -19,6 +19,13 @@ struct ContentView: View {
     @AppStorage("filter.appCaches") private var appCachesFilterRaw: String = SafetyFilter.all.rawValue
     @AppStorage("filter.devTools") private var devToolsFilterRaw: String = SafetyFilter.all.rawValue
     @AppStorage("filter.largeFiles") private var largeFilesCategoryFilterRaw: String = "all"
+
+    /// Large Files search text. Held here rather than inside `LargeFilesView` so the
+    /// page header subtitle can be filtered by it too, and deliberately `@State`
+    /// rather than `@AppStorage` like the filters beside it: a query that survived
+    /// relaunch would silently hide most of the list on next open, with the only clue
+    /// a few characters in a field the user has long forgotten typing.
+    @State private var largeFilesSearchQuery = ""
     @AppStorage(AppearanceMode.userDefaultsKey)
     private var appearanceModeRaw = AppearanceMode.system.rawValue
     private let isRunningPreview = ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
@@ -390,6 +397,7 @@ struct ContentView: View {
                 LargeFilesView(
                     isLoading: store.isScanningLargeFiles,
                     onScan: { Task { await store.scanLargeFiles() } },
+                    searchQuery: $largeFilesSearchQuery,
                     showsPageHeader: false,
                     usesExternalScrollContainer: true
                 )
@@ -397,6 +405,7 @@ struct ContentView: View {
                 LargeFilesView(
                     isLoading: store.isScanningLargeFiles,
                     onScan: { Task { await store.scanLargeFiles() } },
+                    searchQuery: $largeFilesSearchQuery,
                     showsPageHeader: false
                 )
             }
@@ -460,9 +469,13 @@ struct ContentView: View {
         return "\(count) \(itemLabel) · \(formatBytes(bytes)) recoverable"
     }
 
+    /// Mirrors the filtering `LargeFilesView` applies to its list, so the subtitle
+    /// counts the rows the user can actually see. Must stay in step with the search
+    /// and category predicates over there.
     private var largeFilesVisibleForSubtitle: [LargeFile] {
         store.largeFiles.filter { file in
-            largeFilesCategoryFilterRaw == "all" || file.category.rawValue == largeFilesCategoryFilterRaw
+            (largeFilesCategoryFilterRaw == "all" || file.category.rawValue == largeFilesCategoryFilterRaw)
+                && file.matches(searchQuery: largeFilesSearchQuery)
         }
     }
 

--- a/purge/Models/LargeFile.swift
+++ b/purge/Models/LargeFile.swift
@@ -86,6 +86,21 @@ struct LargeFile: Identifiable, Hashable {
     /// made selection feel delayed compared to App Caches.
     let id: String
 
+    /// Everything a search query is matched against, joined once at init for the
+    /// same reason `id` is stored: it's read for every row on every keystroke, so
+    /// rebuilding it per access would re-walk the URL hundreds of times a character.
+    ///
+    /// Holds the display name, the raw parent path, and the `sourceLabel` when there
+    /// is one — so a query finds a row by what it's called *or* where it lives. The
+    /// last two differ for labelled rows: an Ollama model shows "Ollama" but sits in
+    /// `~/.ollama/models`, and both should be findable. Deliberately uses the raw
+    /// path rather than `locationLabel`/`displayDirectoryPath`: that helper resolves
+    /// the home directory through FileManager and is MainActor-isolated under this
+    /// target's default isolation, and `LargeFile` is built inside the scanners'
+    /// detached tasks. The raw path matches the same words anyway ("Downloads" hits
+    /// either form) — only the `~` prefix differs, which nobody searches for.
+    let searchHaystack: String
+
     init(
         path: URL,
         sizeBytes: Int64,
@@ -104,7 +119,31 @@ struct LargeFile: Identifiable, Hashable {
         self.displayNameOverride = displayNameOverride
         self.sourceLabel = sourceLabel
         self.componentPaths = (componentPaths ?? [path]).map(\.standardizedFileURL)
-        self.id = path.standardizedFileURL.path
+        let standardized = path.standardizedFileURL
+        self.id = standardized.path
+        self.searchHaystack = [
+            displayNameOverride ?? path.lastPathComponent,
+            standardized.deletingLastPathComponent().path,
+            sourceLabel,
+        ]
+        .compactMap { $0 }
+        .joined(separator: "\n")
+    }
+
+    /// Whether this row should stay visible for `query`. Whitespace splits the query
+    /// into terms that must *all* match somewhere in `searchHaystack`, so "wedding
+    /// mov" finds the file regardless of what sits between the two words — matching
+    /// the whole string verbatim would find nothing. An all-whitespace or empty query
+    /// matches everything, so callers don't special-case the unfiltered list.
+    ///
+    /// Case- and diacritic-insensitive: someone typing "resume" should still find
+    /// `Résumé.pdf`.
+    func matches(searchQuery query: String) -> Bool {
+        let terms = query.split(whereSeparator: \.isWhitespace)
+        guard !terms.isEmpty else { return true }
+        return terms.allSatisfy { term in
+            searchHaystack.range(of: term, options: [.caseInsensitive, .diacriticInsensitive]) != nil
+        }
     }
     /// Whether this row may leave the list, given the paths a delete run
     /// actually removed. Multi-part rows survive a partial delete: a model whose

--- a/purge/Views/LargeFilesView.swift
+++ b/purge/Views/LargeFilesView.swift
@@ -7,6 +7,11 @@ struct LargeFilesView: View {
 
     let isLoading: Bool
     let onScan: () -> Void
+    /// Owned by the parent rather than held as local `@State` so the page header's
+    /// "N files · X GB to review" subtitle — which `ContentView` renders outside this
+    /// view — counts the same rows the list is actually showing. With the query
+    /// private to this view the header kept advertising the full unfiltered scan.
+    @Binding var searchQuery: String
     var showsPageHeader = true
     var usesExternalScrollContainer = false
 
@@ -38,14 +43,28 @@ struct LargeFilesView: View {
         LargeFileAgeThreshold(rawValue: minAgeDays) ?? .defaultOption
     }
 
+    /// Which categories get a chip. Intentionally keyed off the full scan result and
+    /// not the query, so chips don't appear and vanish under the pointer as the user
+    /// types — a chip that reads 0 is steadier than a row that reflows every keystroke.
     private var availableCategories: [LargeFileCategory] {
         let present = Set(store.largeFiles.map(\.category))
         return LargeFileCategory.allCases.filter { present.contains($0) }
     }
 
+    /// Everything matching the query, before the category chip narrows it further.
+    /// This is what the chip counts are drawn from.
+    private var searchMatches: [LargeFile] {
+        store.largeFiles.filter { $0.matches(searchQuery: searchQuery) }
+    }
+
+    private var hasActiveQuery: Bool {
+        !searchQuery.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
     private var visibleFiles: [LargeFile] {
         let filtered = store.largeFiles.filter { file in
-            categoryFilterRaw == "all" || file.category.rawValue == categoryFilterRaw
+            (categoryFilterRaw == "all" || file.category.rawValue == categoryFilterRaw)
+                && file.matches(searchQuery: searchQuery)
         }
 
         switch currentSort {
@@ -74,7 +93,8 @@ struct LargeFilesView: View {
     private var visibleIndices: [Int] {
         let files = store.largeFiles
         let filtered = files.indices.filter { i in
-            categoryFilterRaw == "all" || files[i].category.rawValue == categoryFilterRaw
+            (categoryFilterRaw == "all" || files[i].category.rawValue == categoryFilterRaw)
+                && files[i].matches(searchQuery: searchQuery)
         }
 
         switch currentSort {
@@ -164,19 +184,23 @@ struct LargeFilesView: View {
             HStack(spacing: 8) {
                 thresholdMenu
                 ageMenu
-                Spacer()
+                Spacer(minLength: 12)
+                LargeFileSearchField(query: $searchQuery)
             }
             .padding(.horizontal, AppDetailPageLayout.horizontalInset)
 
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 4) {
-                    categoryChip(id: "all", title: "All", systemImage: "square.grid.2x2", count: store.largeFiles.count)
+                    // Counts are search-filtered but not category-filtered, so the
+                    // chips answer "where did my matches land?" while a query is
+                    // active instead of advertising rows the query already hid.
+                    categoryChip(id: "all", title: "All", systemImage: "square.grid.2x2", count: searchMatches.count)
                     ForEach(availableCategories) { category in
                         categoryChip(
                             id: category.rawValue,
                             title: category.displayName,
                             systemImage: category.symbolName,
-                            count: store.largeFiles.filter { $0.category == category }.count
+                            count: searchMatches.filter { $0.category == category }.count
                         )
                     }
                 }
@@ -388,10 +412,27 @@ struct LargeFilesView: View {
         VStack(spacing: 4) {
             Text("Nothing here.")
                 .font(.headline)
-            Text("No files match this filter.")
-                .foregroundStyle(.secondary)
+            // Name the query when there is one: with a search field in the chrome the
+            // generic "this filter" leaves the user guessing whether it was the query,
+            // the category, or the size threshold that emptied the list.
+            if hasActiveQuery {
+                Text("No files match \"\(searchQuery)\".")
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .truncationMode(.middle)
+                    .multilineTextAlignment(.center)
+                Button("Clear Search") {
+                    searchQuery = ""
+                }
+                .buttonStyle(.link)
+                .padding(.top, 2)
+            } else {
+                Text("No files match this filter.")
+                    .foregroundStyle(.secondary)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 24)
     }
 
     private var scanningPlaceholder: some View {
@@ -487,6 +528,92 @@ private struct LargeFileSelectAllBar: View {
             AppSortMenu(selection: $sort)
         }
         .scanTabSelectAllRowLayout()
+    }
+}
+
+/// Search field for the Large Files controls row. Deliberately hand-built rather
+/// than `.searchable`: that modifier hangs its field off the enclosing navigation
+/// chrome, which would put it outside this view entirely and give it a different
+/// look on each of the two containers `LargeFilesView` renders into. Geometry and
+/// tokens here are copied from `FilterChip` so it reads as one control family with
+/// the size and last-used menus sitting beside it.
+private struct LargeFileSearchField: View {
+    @Binding var query: String
+
+    @FocusState private var isFocused: Bool
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Matches FilterChip's metrics so the row's controls share a baseline.
+    private static let horizontalPadding: CGFloat = 10
+    private static let verticalPadding: CGFloat = 5
+    private static let labelSize: CGFloat = 13
+
+    private var hasText: Bool { !query.isEmpty }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .imageScale(.small)
+                .foregroundStyle(AppColors.textSecondary)
+                .frame(width: 14, height: 14)
+                .accessibilityHidden(true)
+
+            TextField("Search", text: $query)
+                .textFieldStyle(.plain)
+                .font(.system(size: Self.labelSize))
+                .foregroundStyle(AppColors.textPrimary)
+                .focused($isFocused)
+                .accessibilityLabel("Search large files by name")
+                // Escape clears rather than just unfocusing: an emptied field is the
+                // state the user wants back, and it's the one AppKit search fields
+                // give them.
+                .onExitCommand {
+                    if hasText {
+                        query = ""
+                    } else {
+                        isFocused = false
+                    }
+                }
+
+            // A real Button is fine here — unlike the result rows, this field lives
+            // in the controls chrome and never inside the List, so it can't trigger
+            // the scroll-to-clicked-row behaviour that forces rows to use tap gestures.
+            if hasText {
+                Button {
+                    query = ""
+                    isFocused = true
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .imageScale(.small)
+                        .foregroundStyle(AppColors.textTertiary)
+                }
+                .buttonStyle(.plain)
+                .contentShape(Rectangle())
+                .help("Clear search")
+                .accessibilityLabel("Clear search")
+                .transition(.opacity)
+            }
+        }
+        .padding(.horizontal, Self.horizontalPadding)
+        .padding(.vertical, Self.verticalPadding)
+        .frame(width: 220)
+        .background {
+            Capsule(style: .continuous)
+                .fill(AppColors.bgElevated)
+        }
+        .overlay {
+            Capsule(style: .continuous)
+                .strokeBorder(
+                    isFocused ? AppColors.buttonPrimaryBg : AppColors.borderSubtle,
+                    lineWidth: 1
+                )
+        }
+        .contentShape(Capsule(style: .continuous))
+        // Clicking anywhere in the capsule focuses the field, not just the glyph-width
+        // of text already typed.
+        .onTapGesture { isFocused = true }
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.15), value: isFocused)
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.15), value: hasText)
     }
 }
 
@@ -813,7 +940,7 @@ struct LargeFileDeletionConfirmSheet: View {
 }
 
 #Preview("Large Files") {
-    LargeFilesView(isLoading: false, onScan: {})
+    LargeFilesView(isLoading: false, onScan: {}, searchQuery: .constant(""))
         .environmentObject(PurgeStore())
         .frame(width: 720, height: 560)
 }


### PR DESCRIPTION
Closes #13.

Requested by a user over email: Large Files had no way to find a file by name.

## What this adds

A search field in the Large Files controls row, beside the existing size and last-used menus. It filters the results as you type and composes with the size / last-used / category filters rather than replacing them.

Terms are matched against the **file name, its parent path, and the source label**, so a query finds a row by what it's called *or* where it lives — `downloads zip` works, and so does `Ollama`.

Whitespace splits the query into terms that must **all** match somewhere. That's what lets `house dragon` find both `House.of.the.Dragon.S03E05.mkv` and `House of the Dragon S03E04.mkv` — matching the query verbatim would find neither.

## Verified in the running app

| | |
|---|---|
| No query | 173 files listed |
| `house dragon` | 3 files — matched across both dot- and space-separated names |
| `downloads zip` | 3 files — "downloads" matched the path, "zip" matched the name |
| no-match query | empty state names the query and offers **Clear Search** |

Also covered by 11 unit tests in `PurgeTests/LargeFileSearchTests.swift` (empty/whitespace query, case-insensitivity, diacritics, folder matching, term ordering, boundary straddling, labelled AI-model rows). Full suite: 242 passed, with the one pre-existing `cacheSafetyStillBlocksPersonalMediaPaths` failure that also fails on clean `main`.

## Two decisions worth a look in review

**The search haystack is built once in `init`.** Same reasoning as the existing `id` field — it's read for every row on every keystroke. It deliberately uses the raw parent path rather than `locationLabel`: `displayDirectoryPath` resolves the home directory through FileManager and is MainActor-isolated under this target's `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, while `LargeFile` is constructed inside the scanners' detached tasks. The raw path matches the same words anyway — only the `~` prefix differs, which nobody searches for.

**The query lives in `ContentView`, not as local `@State`.** I started with `@State` in `LargeFilesView` and caught this while verifying: the page header's "N files · X GB to review" subtitle is rendered by `ContentView`, so it kept advertising the full unfiltered scan (`173 files`) while the list showed 3. Hoisting the query lets `largeFilesVisibleForSubtitle` apply the same predicate. It's `@State` rather than `@AppStorage` unlike the filters beside it — a query surviving relaunch would silently hide most of the list on next open, with the only clue a few characters in a field the user forgot typing.

## Scroll stability

Filtering runs through the existing `visibleIndices` path, so the List's `[Int]` row identity — and the scroll behaviour it protects — is untouched. The search field lives in the controls chrome, never inside the List, so its clear button can be a real `Button` without triggering the scroll-to-clicked-row problem that forces result rows to use tap gestures.

## Not addressed here

The selection-vs-query interaction noted in #13: `Select All` operates on the visible (matching) rows, so a user could select all matches, clear the query, and hold a selection they can't see. The delete confirmation sheet enumerates every selected file, so it's mitigated — but if you'd rather clear selection on query change, that's a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search to the Large Files view, matching filenames, folders, and source labels.
  * Search supports multiple terms, case- and diacritic-insensitive matching, and clear-search controls.
  * Category counts and displayed results now update to reflect active searches.
  * Added helpful empty-state messaging when no files match the query.
* **Accessibility**
  * Added keyboard focus handling, Escape-to-clear behavior, accessibility labels, and reduced-motion support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->