### PR TITLE
perf: get scans off the main thread and cut per-render filesystem work

### DIFF
--- a/PurgeTests/FolderSizingConcurrencyTests.swift
+++ b/PurgeTests/FolderSizingConcurrencyTests.swift
@@ -98,6 +98,30 @@ struct FolderSizingConcurrencyTests {
         }
     }
 
+    /// The `du` limiter is process-wide, so a permit abandoned by a cancelled call is lost for
+    /// the lifetime of the process — enough cancellations and sizing would wedge permanently.
+    /// `directorySizes` bails out on cancellation at two points, one of which happens while
+    /// holding a permit, so it has to hand that permit back.
+    ///
+    /// Cancelling more times than there are permits and then measuring normally is the check:
+    /// if any path leaked, capacity would be exhausted and the final call would never return.
+    @Test("Cancelled sizing calls do not leak limiter permits")
+    func cancellationDoesNotLeakLimiterPermits() async throws {
+        let (root, paths) = try makeTree(directories: FolderSizing.duChunkSize * 3, bytesEach: 4 * 1024)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // More iterations than `maxConcurrentDuChunks` (10).
+        for _ in 0..<14 {
+            let task = Task.detached { _ = FolderSizing.directorySizes(at: paths) }
+            task.cancel()
+            _ = await task.value
+        }
+
+        // Would hang rather than fail if permits had leaked.
+        let sizes = FolderSizing.directorySizes(at: paths)
+        #expect(sizes.count == paths.count, "measured \(sizes.count) of \(paths.count) after cancellations")
+    }
+
     /// `du` prints one "Permission denied" line per unreadable directory. That output lands on
     /// stderr, so a runner that leaves stderr undrained wedges the child on a full pipe once the
     /// tree is broad enough — the same deadlock as stdout, just quieter.

--- a/PurgeTests/FolderSizingConcurrencyTests.swift
+++ b/PurgeTests/FolderSizingConcurrencyTests.swift
@@ -60,6 +60,44 @@ struct FolderSizingConcurrencyTests {
         }
     }
 
+    /// The `du` concurrency limiter is process-wide, not per call — a per-call semaphore capped
+    /// one `directorySizes` invocation at ten subprocesses but let N concurrent callers reach
+    /// 10N, which is what the Dev Tools project sizing did (one unbounded task per project root).
+    /// Sharing one semaphore across callers means each call's `DispatchGroup.wait` now also waits
+    /// on permits held by *other* calls, so this checks that every caller still gets a complete,
+    /// correctly-attributed result rather than dropping chunks or returning early.
+    @Test("Concurrent directorySizes callers each get complete results")
+    func concurrentCallersEachGetCompleteResults() async throws {
+        let callers = 6
+        let dirsPerCaller = FolderSizing.duChunkSize + 8 // forces >1 chunk per caller
+        var trees: [(root: URL, paths: [URL])] = []
+        for _ in 0..<callers {
+            trees.append(try makeTree(directories: dirsPerCaller, bytesEach: 4 * 1024))
+        }
+        defer {
+            for tree in trees { try? FileManager.default.removeItem(at: tree.root) }
+        }
+
+        let results = await withTaskGroup(
+            of: (Int, [String: Int64]).self,
+            returning: [(Int, [String: Int64])].self
+        ) { group in
+            for (index, tree) in trees.enumerated() {
+                group.addTask { (index, FolderSizing.directorySizes(at: tree.paths)) }
+            }
+            return await group.reduce(into: []) { $0.append($1) }
+        }
+
+        #expect(results.count == callers)
+        for (index, sizes) in results {
+            let expected = trees[index].paths
+            #expect(sizes.count == expected.count, "caller \(index) measured \(sizes.count) of \(expected.count)")
+            for path in expected {
+                #expect(sizes[path.standardizedFileURL.path] ?? 0 > 0, "caller \(index) lost \(path.lastPathComponent)")
+            }
+        }
+    }
+
     /// `du` prints one "Permission denied" line per unreadable directory. That output lands on
     /// stderr, so a runner that leaves stderr undrained wedges the child on a full pipe once the
     /// tree is broad enough — the same deadlock as stdout, just quieter.

--- a/PurgeTests/ScannerOffMainTests.swift
+++ b/PurgeTests/ScannerOffMainTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+@testable import Purge
+
+/// Lock-protected recorder written from a background executor.
+private final class ThreadRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var sawMainThread = false
+    private var samples = 0
+
+    func record() {
+        lock.lock()
+        defer { lock.unlock() }
+        if Thread.isMainThread { sawMainThread = true }
+        samples += 1
+    }
+
+    var hitMainThread: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return sawMainThread
+    }
+
+    var sampleCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return samples
+    }
+}
+
+/// Covers the concurrency risk introduced by moving the scans off the main actor.
+///
+/// Background: the project builds with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so
+/// `CacheScanner`, `DevScanner`, `LargeFileScanner`, and `AIModelScanner` were implicitly
+/// main-actor isolated and the `Task.detached` inside each `scanStream` hopped straight
+/// back to the main actor — every scan walked the filesystem on the UI thread. They are
+/// now explicitly `nonisolated`.
+///
+/// That isolation property itself is deliberately **not** asserted here. It is only
+/// observable from inside the awaited callee, which would mean adding a hook to
+/// production code purely for the test; and in Swift 5 language mode isolation on
+/// synchronous code is diagnosed but not enforced at runtime, so the obvious
+/// "construct it from a detached task" test passes either way and would be a test that
+/// cannot fail. It was verified instead with a temporary in-app probe logging
+/// `Thread.isMainThread` at the top of each scanner's run function (`true` before the
+/// change, `false` after) — repeat that if the isolation is ever in doubt.
+///
+/// What *is* worth pinning down is the consequence: work that used to be main-actor
+/// serialised now runs concurrently on background executors.
+@Suite("Off-main scanning")
+struct ScannerOffMainTests {
+    /// `CacheScanner` resolves friendly app names during its scan, which goes through
+    /// Launch Services. That used to happen on the main actor and now does not, so this
+    /// guards against it being main-thread-only in practice or returning inconsistent
+    /// results under the concurrent access the scan now subjects it to.
+    @Test func appDisplayNameIsSafeToResolveConcurrentlyOffMain() async {
+        let recorder = ThreadRecorder()
+        let bundleID = "com.apple.finder"
+        let expected = await Task.detached { appDisplayName(forBundleID: bundleID) }.value
+        #expect(expected != nil)
+
+        await withTaskGroup(of: String?.self) { group in
+            for _ in 0..<16 {
+                group.addTask {
+                    recorder.record()
+                    return appDisplayName(forBundleID: bundleID)
+                }
+            }
+            for await name in group {
+                #expect(name == expected)
+            }
+        }
+
+        #expect(recorder.sampleCount == 16)
+        #expect(!recorder.hitMainThread)
+    }
+
+    /// `CacheItem` resolves and stores its `id` and `standardizedPaths` at init instead of
+    /// recomputing them per access — `standardizedFileURL` stats the filesystem, and doing
+    /// it inside SwiftUI body evaluation issued thousands of syscalls per render. The
+    /// stored values must match what the computed versions produced.
+    @Test func cacheItemPrecomputesIdentityConsistently() {
+        let path = URL(fileURLWithPath: "/tmp/./purge-test/../purge-test/cache")
+        let location = CacheLocation(
+            path: path,
+            sizeBytes: 512,
+            lastModified: Date(),
+            folderName: "com.example.test"
+        )
+        let info = SafetyInfo(
+            level: .safe, headline: "h", explanation: "e", recoverySteps: "r", reinstallCommand: nil
+        )
+
+        let ungrouped = CacheItem(definitionKey: nil, location: location, appName: "T", safetyInfo: info)
+        #expect(ungrouped.id == "path:\(path.standardizedFileURL.path)")
+        #expect(ungrouped.standardizedPaths == [path.standardizedFileURL.path])
+        // The stored path is what `sizeBytes(at:)` matches against, including when the
+        // caller passes a non-standardized URL.
+        #expect(ungrouped.sizeBytes(at: path) == 512)
+
+        let grouped = CacheItem(
+            definitionKey: "some-key", locations: [location], appName: "T", safetyInfo: info
+        )
+        #expect(grouped.id == "def:some-key")
+        #expect(grouped.standardizedPaths == [path.standardizedFileURL.path])
+
+        // Re-deriving through `withLocations` must not lose the identity.
+        #expect(grouped.withLocations([location]).id == grouped.id)
+        #expect(ungrouped.withLocations([location]).id == ungrouped.id)
+    }
+
+    /// `DevTool.id` is likewise stored now; it must still be order-independent across
+    /// `paths`, because that is what made it a stable identity in the first place.
+    @Test func devToolIdIsStableRegardlessOfPathOrder() {
+        let a = URL(fileURLWithPath: "/tmp/purge-test/a")
+        let b = URL(fileURLWithPath: "/tmp/purge-test/b")
+        let info = SafetyInfo(
+            level: .safe, headline: "h", explanation: "e", recoverySteps: "r", reinstallCommand: nil
+        )
+        func tool(_ paths: [URL]) -> DevTool {
+            DevTool(
+                definitionKey: "k", toolName: "T", paths: paths,
+                sizeBytes: 0, isDetected: true, safetyInfo: info
+            )
+        }
+        #expect(tool([a, b]).id == tool([b, a]).id)
+        #expect(tool([a]).id != tool([b]).id)
+    }
+}

--- a/PurgeTests/ScannerOffMainTests.swift
+++ b/PurgeTests/ScannerOffMainTests.swift
@@ -109,6 +109,14 @@ struct ScannerOffMainTests {
         #expect(ungrouped.withLocations([location]).id == ungrouped.id)
     }
 
+    /// The sidebar hero's counting animation is tuned to the scan flush cadence, so the
+    /// exposed seconds value must actually match `ScanCoalesce.flushInterval`. A wrong
+    /// `Duration` decomposition here would silently desynchronise the digit roll.
+    @MainActor
+    @Test func scanFlushIntervalIsExposedInSeconds() {
+        #expect(abs(PurgeStore.scanFlushIntervalSeconds - 0.14) < 0.0001)
+    }
+
     /// `DevTool.id` is likewise stored now; it must still be order-independent across
     /// `paths`, because that is what made it a stable identity in the first place.
     @Test func devToolIdIsStableRegardlessOfPathOrder() {

--- a/purge/ContentView.swift
+++ b/purge/ContentView.swift
@@ -763,7 +763,9 @@ struct SidebarSummaryView: View {
     /// kept for the settled value, where there is a real start and end to ease between.
     private var countingAnimation: Animation? {
         guard !reduceMotion else { return nil }
-        return isCountingUp ? .linear(duration: 0.14) : .easeInOut(duration: 0.45)
+        return isCountingUp
+            ? .linear(duration: PurgeStore.scanFlushIntervalSeconds)
+            : .easeInOut(duration: 0.45)
     }
 
     private var isCountingUp: Bool {

--- a/purge/ContentView.swift
+++ b/purge/ContentView.swift
@@ -300,6 +300,12 @@ struct ContentView: View {
         .background(AppColors.bgBase)
     }
 
+    // Deliberately a plain `switch`, i.e. the incoming tab is built fresh. Keeping
+    // visited tabs mounted in a ZStack and toggling opacity was tried and measured: it
+    // helped the first few switches but was a net regression (p95 33ms → 50ms with all
+    // tabs mounted, 41ms with just the two scan tabs), because a mounted tab still
+    // re-evaluates its body on every store publish. Don't re-propose it without new
+    // measurements.
     @ViewBuilder
     private var tabBody: some View {
         switch store.selectedTab {
@@ -496,7 +502,7 @@ struct ContentView: View {
 
     private var appCachesVisibleItems: [CacheItem] {
         store.cacheItems.filter {
-            appCachesSafetyFilter.matches($0.safetyInfo) && !isVisuallyRemovedBySafeCleanup($0)
+            appCachesSafetyFilter.matches($0.safetyInfo) && !store.isVisuallyRemovedBySafeCleanup($0)
         }
     }
 
@@ -571,33 +577,14 @@ struct ContentView: View {
     private func devToolVisible(_ tool: DevTool) -> Bool {
         tool.isDetected &&
             devToolsSafetyFilter.matches(tool.safetyInfo) &&
-            !isVisuallyRemovedBySafeCleanup(tool)
+            !store.isVisuallyRemovedBySafeCleanup(tool)
     }
 
     private func projectArtifactVisible(_ artifact: ProjectCacheArtifact) -> Bool {
         devToolsSafetyFilter.matches(artifact.safetyInfo) &&
-            !isVisuallyRemovedBySafeCleanup(artifact)
+            !store.isVisuallyRemovedBySafeCleanup(artifact)
     }
 
-    private func isVisuallyRemovedBySafeCleanup(_ item: CacheItem) -> Bool {
-        let rowPaths = Set(item.locations.map { $0.path.standardizedFileURL.path })
-        let targetedPaths = rowPaths.intersection(store.interactiveSafeCleanupTargetPaths)
-        guard !targetedPaths.isEmpty else { return false }
-        return targetedPaths.isSubset(of: store.interactiveSafeCleanupRemovedPaths)
-    }
-
-    private func isVisuallyRemovedBySafeCleanup(_ tool: DevTool) -> Bool {
-        let rowPaths = Set(tool.paths.map { $0.standardizedFileURL.path })
-        let targetedPaths = rowPaths.intersection(store.interactiveSafeCleanupTargetPaths)
-        guard !targetedPaths.isEmpty else { return false }
-        return targetedPaths.isSubset(of: store.interactiveSafeCleanupRemovedPaths)
-    }
-
-    private func isVisuallyRemovedBySafeCleanup(_ artifact: ProjectCacheArtifact) -> Bool {
-        let path = artifact.path.standardizedFileURL.path
-        return store.interactiveSafeCleanupTargetPaths.contains(path)
-            && store.interactiveSafeCleanupRemovedPaths.contains(path)
-    }
 }
 
 private struct DiskSummaryRefreshModifier: ViewModifier {
@@ -757,7 +744,7 @@ struct SidebarSummaryView: View {
                     .foregroundStyle(safeToCleanBytes > 0 ? .primary : .secondary)
                     .monospacedDigit()
                     .contentTransition(reduceMotion ? .identity : .numericText())
-                    .animation(reduceMotion ? nil : .easeInOut(duration: 0.45), value: safeToCleanBytes)
+                    .animation(countingAnimation, value: safeToCleanBytes)
             }
         }
         .accessibilityElement(children: .combine)
@@ -768,14 +755,28 @@ struct SidebarSummaryView: View {
         store.safeRecoverableBytes
     }
 
-    /// Before the first size pass lands the number would read a misleading 0, so the hero
-    /// shows a measuring indicator until a real total is available.
-    private var isSafeToCleanLoading: Bool {
-        guard store.safeRecoverableBytes == 0 else { return false }
-        return store.scanPhase == .scanning
+    /// While a scan is running the totals are re-published on a fixed ~140ms beat, so a
+    /// 0.45s eased roll would be retargeted a third of the way through its curve on every
+    /// tick — the digits never reach the ease-out and the climb reads as a stutter rather
+    /// than a count. A linear roll matched to the publish cadence hands off cleanly from
+    /// one tick to the next, so the figure rises continuously; the longer eased curve is
+    /// kept for the settled value, where there is a real start and end to ease between.
+    private var countingAnimation: Animation? {
+        guard !reduceMotion else { return nil }
+        return isCountingUp ? .linear(duration: 0.14) : .easeInOut(duration: 0.45)
+    }
+
+    private var isCountingUp: Bool {
+        store.scanPhase == .scanning
             || store.scanPhase == .cancelling
             || store.isEnrichingGeneral
             || store.isEnrichingDeveloper
+    }
+
+    /// Before the first size pass lands the number would read a misleading 0, so the hero
+    /// shows a measuring indicator until a real total is available.
+    private var isSafeToCleanLoading: Bool {
+        store.safeRecoverableBytes == 0 && isCountingUp
     }
 
 
@@ -837,7 +838,7 @@ struct SidebarSummaryView: View {
             .foregroundStyle(.tertiary)
             .monospacedDigit()
             .contentTransition(reduceMotion ? .identity : .numericText())
-            .animation(reduceMotion ? nil : .easeInOut(duration: 0.45), value: reclaimableTotalBytes)
+            .animation(countingAnimation, value: reclaimableTotalBytes)
             .frame(maxWidth: .infinity, alignment: .center)
     }
 

--- a/purge/Menu/MenuBarView.swift
+++ b/purge/Menu/MenuBarView.swift
@@ -65,7 +65,14 @@ private enum MenuLayout {
 /// while the panel is open, because only real menu tracking pins it.
 struct MenuBarContentView: View {
     @ObservedObject var model: MenuViewModel
-    @EnvironmentObject private var store: PurgeStore
+    /// Deliberately a plain reference, NOT `@EnvironmentObject`: this panel renders
+    /// entirely from `model.state` and touches the store only to hand it to
+    /// `model.attach`. Observing it subscribed the panel to every `PurgeStore`
+    /// publish, and because the `.window` panel hierarchy stays mounted while
+    /// closed, each publish drove AppKit's `NSStatusItem` replicant redraw — which
+    /// rasterises the status item's view tree into a bitmap on the main thread.
+    /// During a scan that was the single largest main-thread cost in the app.
+    let store: PurgeStore
     /// The panel hierarchy stays alive while the panel is hidden (the `.window`
     /// panel is reused across opens), so every repeating timer in this view
     /// must be gated on this flag or it keeps waking the app while closed.

--- a/purge/Models/CacheItem.swift
+++ b/purge/Models/CacheItem.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct CacheLocation: Hashable {
+nonisolated struct CacheLocation: Hashable {
     let path: URL
     let sizeBytes: Int64
     let lastModified: Date
@@ -8,7 +8,7 @@ struct CacheLocation: Hashable {
     let folderName: String
 }
 
-struct CacheItem: Identifiable, Hashable {
+nonisolated struct CacheItem: Identifiable, Hashable {
     /// Canonical `explanations.json` key; `nil` means this row is not merged with others.
     let definitionKey: String?
     let locations: [CacheLocation]
@@ -20,12 +20,18 @@ struct CacheItem: Identifiable, Hashable {
     /// Filled asynchronously; `.clean` means no Git repo touched or repo is tidy.
     var gitStatus: GitWorktreeStatus
 
-    var id: String {
-        if let definitionKey {
-            return "def:\(definitionKey)"
-        }
-        return "path:\(path.standardizedFileURL.path)"
-    }
+    /// Resolved once at init rather than on every access.
+    ///
+    /// `standardizedFileURL` is not a string operation — it stats the filesystem, and
+    /// profiling caught it as `faccessat`/`__mac_syscall` samples *inside SwiftUI body
+    /// evaluation*: `id` is read once per row by the `ForEach` and again for every item
+    /// by each selection/count/total helper, so one render issued thousands of syscalls
+    /// on the main thread. `locations` and `definitionKey` are both `let`, so this
+    /// cannot go stale.
+    let id: String
+
+    /// Standardized `locations` paths, in order. Same reasoning as `id`.
+    let standardizedPaths: [String]
 
     var paths: [URL] {
         locations.map(\.path)
@@ -54,7 +60,8 @@ struct CacheItem: Identifiable, Hashable {
 
     func sizeBytes(at path: URL) -> Int64 {
         let key = path.standardizedFileURL.path
-        return locations.first { $0.path.standardizedFileURL.path == key }?.sizeBytes ?? 0
+        guard let index = standardizedPaths.firstIndex(of: key) else { return 0 }
+        return locations[index].sizeBytes
     }
 
     func withLocations(_ locations: [CacheLocation]) -> CacheItem {
@@ -97,6 +104,8 @@ struct CacheItem: Identifiable, Hashable {
         self.safetyInfo = safetyInfo
         self.reinstallSafety = reinstallSafety
         self.gitStatus = gitStatus
+        self.standardizedPaths = [location.path.standardizedFileURL.path]
+        self.id = definitionKey.map { "def:\($0)" } ?? "path:\(self.standardizedPaths[0])"
     }
 
     /// Grouped row with one or more locations.
@@ -116,5 +125,7 @@ struct CacheItem: Identifiable, Hashable {
         self.safetyInfo = safetyInfo
         self.reinstallSafety = reinstallSafety
         self.gitStatus = gitStatus
+        self.standardizedPaths = locations.map { $0.path.standardizedFileURL.path }
+        self.id = "def:\(definitionKey)"
     }
 }

--- a/purge/Models/DevTool.swift
+++ b/purge/Models/DevTool.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct DevTool: Identifiable, Hashable {
+nonisolated struct DevTool: Identifiable, Hashable {
     /// Canonical `explanations.json` key used for safety copy and grouping.
     let definitionKey: String
     let toolName: String
@@ -13,13 +13,10 @@ struct DevTool: Identifiable, Hashable {
     var safetyInfo: SafetyInfo
     let reinstallSafety: ReinstallSafetyStatus
 
-    var id: String {
-        let pathKey = paths
-            .map { $0.standardizedFileURL.path }
-            .sorted()
-            .joined(separator: "|")
-        return "dev:\(definitionKey):\(pathKey)"
-    }
+    /// Built once at init. Every access previously standardized each path (a filesystem
+    /// stat), sorted, and joined — and `id` is read per row and per selection lookup
+    /// during SwiftUI body evaluation. All inputs are `let`, so this cannot go stale.
+    let id: String
 
     /// Path used as the user-override key. Defaults to the first declared path
     /// because a tool entry typically resolves to a single canonical folder.
@@ -51,5 +48,10 @@ struct DevTool: Identifiable, Hashable {
         self.isDetected = isDetected
         self.safetyInfo = safetyInfo
         self.reinstallSafety = reinstallSafety
+        let pathKey = paths
+            .map { $0.standardizedFileURL.path }
+            .sorted()
+            .joined(separator: "|")
+        self.id = "dev:\(definitionKey):\(pathKey)"
     }
 }

--- a/purge/Models/DevTool.swift
+++ b/purge/Models/DevTool.swift
@@ -18,6 +18,10 @@ nonisolated struct DevTool: Identifiable, Hashable {
     /// during SwiftUI body evaluation. All inputs are `let`, so this cannot go stale.
     let id: String
 
+    /// Standardized `paths`, in order. Same reasoning as `id`: the safe-cleanup row-hiding
+    /// check reads these per tool per render while a cleanup is running.
+    let standardizedPaths: [String]
+
     /// Path used as the user-override key. Defaults to the first declared path
     /// because a tool entry typically resolves to a single canonical folder.
     var primaryOverridePath: URL? { paths.first }
@@ -48,10 +52,8 @@ nonisolated struct DevTool: Identifiable, Hashable {
         self.isDetected = isDetected
         self.safetyInfo = safetyInfo
         self.reinstallSafety = reinstallSafety
-        let pathKey = paths
-            .map { $0.standardizedFileURL.path }
-            .sorted()
-            .joined(separator: "|")
-        self.id = "dev:\(definitionKey):\(pathKey)"
+        let standardized = paths.map { $0.standardizedFileURL.path }
+        self.standardizedPaths = standardized
+        self.id = "dev:\(definitionKey):\(standardized.sorted().joined(separator: "|"))"
     }
 }

--- a/purge/Models/LargeFile.swift
+++ b/purge/Models/LargeFile.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-enum LargeFileCategory: String, CaseIterable, Identifiable, Hashable {
+nonisolated enum LargeFileCategory: String, CaseIterable, Identifiable, Hashable {
     case video
     case audio
     case image
@@ -59,7 +59,7 @@ enum LargeFileCategory: String, CaseIterable, Identifiable, Hashable {
     }
 }
 
-struct LargeFile: Identifiable, Hashable {
+nonisolated struct LargeFile: Identifiable, Hashable {
     let path: URL
     let sizeBytes: Int64
     /// Most recent of last-accessed and last-modified. The file's last touched time.

--- a/purge/Models/ProjectModels.swift
+++ b/purge/Models/ProjectModels.swift
@@ -29,7 +29,7 @@ enum NodePackageManager: String, Hashable, Sendable {
     }
 }
 
-enum ProjectType: Hashable, Sendable {
+nonisolated enum ProjectType: Hashable, Sendable {
     case node
     case rust
     case flutter
@@ -51,7 +51,7 @@ enum ProjectType: Hashable, Sendable {
 }
 
 /// High-level grouping of removable folders tied to one project directory.
-enum DeletableArtifactKind: String, Hashable, Sendable {
+nonisolated enum DeletableArtifactKind: String, Hashable, Sendable {
     case nodeModules = "node_modules"
     case venv
     case dotGradle = ".gradle"
@@ -87,7 +87,7 @@ enum DeletableArtifactKind: String, Hashable, Sendable {
 }
 
 /// One folder under a detected project shown in lists and selectable for deletion.
-struct ProjectCacheArtifact: Identifiable, Hashable {
+nonisolated struct ProjectCacheArtifact: Identifiable, Hashable {
     var id: String { path.path }
 
     let kind: DeletableArtifactKind
@@ -111,7 +111,7 @@ struct ProjectCacheArtifact: Identifiable, Hashable {
 }
 
 /// A collapsible Dev Tools group: multiple artifacts under one project root.
-struct ProjectGroup: Identifiable, Hashable {
+nonisolated struct ProjectGroup: Identifiable, Hashable {
     var id: String { rootPath.path }
 
     let displayName: String

--- a/purge/Models/SafetyInfo.swift
+++ b/purge/Models/SafetyInfo.swift
@@ -11,7 +11,7 @@ import SwiftUI
 /// fallback for a folder the resolver could not identify, and such items are
 /// dropped at the scan-results assembly boundary (see
 /// `canSurfaceInScanResults`).
-enum SafetyLevel: String, CaseIterable, Codable, Hashable {
+nonisolated enum SafetyLevel: String, CaseIterable, Codable, Hashable {
     case safe
     case medium
     case unknown
@@ -40,6 +40,10 @@ enum SafetyLevel: String, CaseIterable, Codable, Hashable {
         }
     }
 
+    /// The type is `nonisolated` so scanners can build it off the main actor; this one
+    /// member reads `AppColors`, which is main-actor state, and is only ever called from
+    /// a view body.
+    @MainActor
     var color: Color {
         switch self {
         case .safe: return AppColors.tagSafeText
@@ -61,7 +65,7 @@ enum SafetyLevel: String, CaseIterable, Codable, Hashable {
     }
 }
 
-struct SafetyInfo: Hashable {
+nonisolated struct SafetyInfo: Hashable {
     let level: SafetyLevel
     let headline: String
     let explanation: String

--- a/purge/Models/SimulatorDevice.swift
+++ b/purge/Models/SimulatorDevice.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct SimulatorDevice: Identifiable, Hashable {
+nonisolated struct SimulatorDevice: Identifiable, Hashable {
     let id: UUID
     let deviceName: String
     let runtimeVersion: String

--- a/purge/Services/AIModelScanPolicy.swift
+++ b/purge/Services/AIModelScanPolicy.swift
@@ -12,7 +12,7 @@ enum AIModelScanPolicy {
         case ollama
         case lmStudio
 
-        var displayName: String {
+        nonisolated var displayName: String {
             switch self {
             case .ollama: return "Ollama"
             case .lmStudio: return "LM Studio"

--- a/purge/Services/AIModelScanner.swift
+++ b/purge/Services/AIModelScanner.swift
@@ -8,7 +8,10 @@ import Foundation
 /// a model without Ollama noticing — the manifest would still claim the model
 /// is installed. Blobs are also shared between models, so the reclaimable size
 /// of a model is only the blobs no other manifest references.
-final class AIModelScanner {
+/// `nonisolated` for the same reason as `LargeFileScanner` — see the note there.
+/// Without it the `Task.detached` in `scanStream` hops back to the main actor and
+/// this runs its manifest walk on the UI thread.
+nonisolated final class AIModelScanner {
     func scanStream(minBytes: Int64, staleDays: Int) -> AsyncStream<LargeFile> {
         AsyncStream { continuation in
             let task = Task.detached(priority: .userInitiated) {

--- a/purge/Services/BrandIconService.swift
+++ b/purge/Services/BrandIconService.swift
@@ -46,22 +46,40 @@ final class BrandIconService {
 
     private let imageCache = NSCache<NSString, NSImage>()
 
+    /// Fully-resolved row icons, keyed by the row's icon identity plus appearance.
+    ///
+    /// Resolution is not cheap: a miss walks the bundled-asset lookup, then Launch
+    /// Services, then up to nine `fileExists` probes. `AdaptiveBrandIconImage` resolves
+    /// inside `body`, so without this every re-render of a visible row repeated that
+    /// work on the main thread — and during a scan the rows re-render on every flush.
+    private var rowIconCache: [String: BrandRowIcon] = [:]
+
+    /// Installed-app lookups, **including misses** (`nil`). The miss is the expensive
+    /// case — it is the one that runs the full nine-probe filesystem walk and finds
+    /// nothing — so caching only hits would leave the hot path uncached.
+    private var installedAppIconCache: [String: NSImage?] = [:]
+
     private init() {}
 
     // MARK: - Public API
 
     func rowIcon(forCacheItem item: CacheItem, appearance: BrandIconAppearance) -> BrandRowIcon {
-        if let key = item.definitionKey, let image = resolve(definitionKey: key, appearance: appearance) {
-            return .bitmap(image)
+        // Keyed on what resolution actually reads, not on the item: size and timestamps
+        // churn constantly during a scan but never change which icon a row gets.
+        let key = "c|\(appearance)|\(item.definitionKey ?? "")|\(item.bundleID)|\(item.appName)"
+        return cachedRowIcon(key: key) {
+            if let key = item.definitionKey, let image = resolve(definitionKey: key, appearance: appearance) {
+                return .bitmap(image)
+            }
+            if let key = ExplanationDatabase.definitionKey(forFolderName: item.bundleID),
+               let image = resolve(definitionKey: key, appearance: appearance) {
+                return .bitmap(image)
+            }
+            if let image = resolve(appName: item.appName, bundleID: item.bundleID, appearance: appearance) {
+                return .bitmap(image)
+            }
+            return .symbol(Self.fallbackFolderSymbolName)
         }
-        if let key = ExplanationDatabase.definitionKey(forFolderName: item.bundleID),
-           let image = resolve(definitionKey: key, appearance: appearance) {
-            return .bitmap(image)
-        }
-        if let image = resolve(appName: item.appName, bundleID: item.bundleID, appearance: appearance) {
-            return .bitmap(image)
-        }
-        return .symbol(Self.fallbackFolderSymbolName)
     }
 
     func rowIcon(forCacheItem item: CacheItem, colorScheme: ColorScheme) -> BrandRowIcon {
@@ -69,10 +87,12 @@ final class BrandIconService {
     }
 
     func rowIcon(forDevTool tool: DevTool, appearance: BrandIconAppearance) -> BrandRowIcon {
-        if let image = resolve(definitionKey: tool.definitionKey, appearance: appearance) {
-            return .bitmap(image)
+        cachedRowIcon(key: "t|\(appearance)|\(tool.definitionKey)") {
+            if let image = resolve(definitionKey: tool.definitionKey, appearance: appearance) {
+                return .bitmap(image)
+            }
+            return .symbol(Self.fallbackFolderSymbolName)
         }
-        return .symbol(Self.fallbackFolderSymbolName)
     }
 
     func rowIcon(forDevTool tool: DevTool, colorScheme: ColorScheme) -> BrandRowIcon {
@@ -80,6 +100,16 @@ final class BrandIconService {
     }
 
     func rowIcon(forProjectGroup group: ProjectGroup, appearance: BrandIconAppearance) -> BrandRowIcon {
+        // The dominant artifact can change as sizes land mid-scan, so it belongs in the
+        // key rather than being pinned to whatever was largest on first resolve.
+        let dominantPath = group.artifacts.max(by: { $0.sizeBytes < $1.sizeBytes })?.path.path ?? ""
+        let key = "g|\(appearance)|\(dominantPath)|\(group.inferredTypes.map(String.init(describing:)).joined(separator: ","))"
+        return cachedRowIcon(key: key) {
+            uncachedRowIcon(forProjectGroup: group, appearance: appearance)
+        }
+    }
+
+    private func uncachedRowIcon(forProjectGroup group: ProjectGroup, appearance: BrandIconAppearance) -> BrandRowIcon {
         if let dominant = group.artifacts.max(by: { $0.sizeBytes < $1.sizeBytes }) {
             if let slug = BrandIconMapping.slug(forArtifactKind: dominant.kind),
                let image = bundledBrandImage(slug: slug, appearance: appearance) {
@@ -102,6 +132,15 @@ final class BrandIconService {
     }
 
     // MARK: - Resolution
+
+    private func cachedRowIcon(key: String, resolve: () -> BrandRowIcon) -> BrandRowIcon {
+        if let cached = rowIconCache[key] {
+            return cached
+        }
+        let icon = resolve()
+        rowIconCache[key] = icon
+        return icon
+    }
 
     private func resolve(definitionKey key: String, appearance: BrandIconAppearance) -> NSImage? {
         if !BrandIconMapping.isBundleOnlyDefinitionKey(key),
@@ -184,16 +223,31 @@ final class BrandIconService {
 
     func installedAppIcon(bundleID: String) -> NSImage? {
         guard !bundleID.isEmpty else { return nil }
-        if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
-            return NSWorkspace.shared.icon(forFile: appURL.path)
+        let cacheKey = "b|\(bundleID)"
+        if let cached = installedAppIconCache[cacheKey] {
+            return cached
         }
-        return nil
+        var image: NSImage?
+        if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
+            image = NSWorkspace.shared.icon(forFile: appURL.path)
+        }
+        installedAppIconCache[cacheKey] = image
+        return image
     }
 
     func installedAppIcon(appName: String) -> NSImage? {
         let trimmed = appName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
+        let cacheKey = "n|\(trimmed)"
+        if let cached = installedAppIconCache[cacheKey] {
+            return cached
+        }
+        let image = uncachedInstalledAppIcon(trimmedAppName: trimmed)
+        installedAppIconCache[cacheKey] = image
+        return image
+    }
 
+    private func uncachedInstalledAppIcon(trimmedAppName trimmed: String) -> NSImage? {
         var candidates = [trimmed]
         if !trimmed.hasSuffix(".app") {
             candidates.append("\(trimmed).app")

--- a/purge/Services/CacheScanner.swift
+++ b/purge/Services/CacheScanner.swift
@@ -7,7 +7,12 @@ enum CacheScanEvent {
     case sizeResolved(path: String, sizeBytes: Int64, lastModified: Date)
 }
 
-final class CacheScanner {
+/// `nonisolated` is load-bearing — see the note on `LargeFileScanner`. Under
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` this type would be implicitly
+/// main-actor isolated, so the `Task.detached` in `scanGeneralStream` hopped straight
+/// back and ran the whole cache discovery + sizing pass on the UI thread. A probe
+/// confirmed `runGeneralScan` executing with `Thread.isMainThread == true`.
+nonisolated final class CacheScanner {
     private struct SizeJob {
         let path: URL
     }

--- a/purge/Services/DeletionSafetyPolicy.swift
+++ b/purge/Services/DeletionSafetyPolicy.swift
@@ -186,14 +186,6 @@ enum DeletionSafetyPolicy {
         ]
     }
 
-    /// Absolute paths (and their descendants) we are explicitly authorized to delete.
-    ///
-    /// Audit note: every entry below resolves to a regenerable cache, build
-    /// artifact, or log directory — nothing here holds non-recoverable user
-    /// data. A handful of entries are flagged `AUDIT` where the folder holds
-    /// re-creatable but not-instantly-regenerated state; those are surfaced as
-    /// "Check First" by their classifiers (never silently downgraded to Safe),
-    /// and are called out here so the risk stays visible.
     /// The user's home path, resolved once. `FileManager.homeDirectoryForCurrentUser`
     /// plus `standardizedFileURL` was previously re-run inside every protection check,
     /// several times per item, on every flush — it cannot change while the app runs.
@@ -209,6 +201,14 @@ enum DeletionSafetyPolicy {
         home == cachedHomePath ? cachedWhitelistedPrefixes : whitelistedAbsolutePrefixes(home: home)
     }
 
+    /// Absolute paths (and their descendants) we are explicitly authorized to delete.
+    ///
+    /// Audit note: every entry below resolves to a regenerable cache, build
+    /// artifact, or log directory — nothing here holds non-recoverable user
+    /// data. A handful of entries are flagged `AUDIT` where the folder holds
+    /// re-creatable but not-instantly-regenerated state; those are surfaced as
+    /// "Check First" by their classifiers (never silently downgraded to Safe),
+    /// and are called out here so the risk stays visible.
     nonisolated static func whitelistedAbsolutePrefixes(home: String) -> [String] {
         [
             "\(home)/Library/Caches",

--- a/purge/Services/DeletionSafetyPolicy.swift
+++ b/purge/Services/DeletionSafetyPolicy.swift
@@ -194,6 +194,21 @@ enum DeletionSafetyPolicy {
     /// re-creatable but not-instantly-regenerated state; those are surfaced as
     /// "Check First" by their classifiers (never silently downgraded to Safe),
     /// and are called out here so the risk stays visible.
+    /// The user's home path, resolved once. `FileManager.homeDirectoryForCurrentUser`
+    /// plus `standardizedFileURL` was previously re-run inside every protection check,
+    /// several times per item, on every flush — it cannot change while the app runs.
+    nonisolated static let cachedHomePath: String =
+        FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+
+    /// Prebuilt for `cachedHomePath`, which is the only value production ever passes.
+    /// The uncached form allocated ~20 interpolated strings per call, per item, per flush.
+    private nonisolated static let cachedWhitelistedPrefixes: [String] =
+        whitelistedAbsolutePrefixes(home: cachedHomePath)
+
+    nonisolated static func whitelistedPrefixes(home: String) -> [String] {
+        home == cachedHomePath ? cachedWhitelistedPrefixes : whitelistedAbsolutePrefixes(home: home)
+    }
+
     nonisolated static func whitelistedAbsolutePrefixes(home: String) -> [String] {
         [
             "\(home)/Library/Caches",
@@ -279,10 +294,33 @@ enum DeletionSafetyPolicy {
     }
 
     /// Whether Purge may offer this path for manual or scheduled cleanup (no admin prompt).
+    ///
+    /// Memoised by path. The verdict is a pure function of the path and the static
+    /// allowlists — nothing here reads size, mtime, or user state — so a repeat lookup
+    /// can only produce the same answer. This matters because `filterCacheItems` runs
+    /// over the *entire* accumulated result set on every scan flush, so without a cache
+    /// the policy was re-evaluated (items x flushes) times on the main thread; profiling
+    /// a scan put essentially the whole per-flush cost inside this one call.
     nonisolated static func isOfferedForCleanup(_ url: URL) -> Bool {
-        if requiresAdminPrivileges(for: url) { return false }
-        return evaluate(url) == .allow
+        let key = url.standardizedFileURL.path
+
+        offeredForCleanupLock.lock()
+        let cached = offeredForCleanupCache[key]
+        offeredForCleanupLock.unlock()
+        if let cached { return cached }
+
+        // Evaluated outside the lock: the scanners call this concurrently, and holding
+        // the lock across the evaluation would serialise them onto one another.
+        let verdict = !requiresAdminPrivileges(for: url) && evaluate(url) == .allow
+
+        offeredForCleanupLock.lock()
+        offeredForCleanupCache[key] = verdict
+        offeredForCleanupLock.unlock()
+        return verdict
     }
+
+    private nonisolated(unsafe) static var offeredForCleanupCache: [String: Bool] = [:]
+    private nonisolated static let offeredForCleanupLock = NSLock()
 
     nonisolated static func filterCacheItems(_ items: [CacheItem]) -> [CacheItem] {
         items.compactMap(filterCacheItem)
@@ -354,7 +392,7 @@ enum DeletionSafetyPolicy {
 
     nonisolated static func shouldDeleteContentsOnly(_ url: URL) -> Bool {
         let path = url.standardizedFileURL.path
-        let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+        let home = cachedHomePath
         if contentsOnlyPrefixes(home: home).contains(path) { return true }
         // Clear the Telegram media cache's contents but leave the `media`
         // directory itself (and everything above it) in place.
@@ -364,7 +402,7 @@ enum DeletionSafetyPolicy {
 
     nonisolated static func isProtectedSystemCache(_ url: URL) -> Bool {
         let standardized = url.standardizedFileURL
-        let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+        let home = cachedHomePath
         let cachesPrefix = "\(home)/Library/Caches"
         let path = standardized.path
         guard path.hasPrefix(cachesPrefix + "/") else { return false }
@@ -384,7 +422,7 @@ enum DeletionSafetyPolicy {
 
     nonisolated static func isProtectedLogFolder(_ url: URL) -> Bool {
         let standardized = url.standardizedFileURL
-        let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+        let home = cachedHomePath
         let logsPrefix = "\(home)/Library/Logs"
         let path = standardized.path
         guard path == logsPrefix || path.hasPrefix(logsPrefix + "/") else { return false }
@@ -396,7 +434,7 @@ enum DeletionSafetyPolicy {
 
     nonisolated static func isProtectedAppContainer(_ url: URL) -> Bool {
         let standardized = url.standardizedFileURL
-        let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+        let home = cachedHomePath
         let containersPrefix = "\(home)/Library/Containers/"
         let path = standardized.path
         guard path.hasPrefix(containersPrefix) else { return false }
@@ -529,8 +567,7 @@ enum DeletionSafetyPolicy {
     nonisolated static func evaluate(_ url: URL) -> DeletionSafetyDecision {
         let standardized = url.standardizedFileURL
         let path = standardized.path
-        let homeURL = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL
-        let home = homeURL.path
+        let home = cachedHomePath
 
         if isProtectedSystemCache(standardized)
             || isProtectedAppContainer(standardized)
@@ -538,7 +575,7 @@ enum DeletionSafetyPolicy {
             return .blockedNeverDelete
         }
 
-        for allowed in whitelistedAbsolutePrefixes(home: home) {
+        for allowed in whitelistedPrefixes(home: home) {
             if path == allowed || path.hasPrefix(allowed + "/") {
                 return .allow
             }

--- a/purge/Services/DevScanner.swift
+++ b/purge/Services/DevScanner.swift
@@ -927,72 +927,97 @@ nonisolated final class DevScanner {
     ) async -> (groups: [ProjectGroup], artifactsSized: Int) {
         guard !discovered.isEmpty else { return ([], 0) }
 
+        // Bounded rather than one task per discovered root. `sizeProjectGroup` blocks its
+        // thread inside `FolderSizing.directorySizes` (a `DispatchGroup.wait`), so an
+        // unbounded group parks one cooperative-pool thread per project — and the pool is
+        // core-count sized and already shared with the cache scan's fan-out. The `du`
+        // subprocess count is capped separately and process-wide by `FolderSizing`.
         return await withTaskGroup(of: (ProjectGroup?, Int).self) { group in
-            for (rootURL, types) in discovered {
-                group.addTask { [rootURL, types] in
-                    let rows = DevScanner.collectArtifacts(projectRoot: rootURL, types: types)
-                    guard !rows.isEmpty else { return (nil, 0) }
+            var pending = discovered.makeIterator()
+            var inFlight = 0
 
-                    let artifactPaths = rows.map(\.path)
-                    let sizesByPath = FolderSizing.directorySizes(at: artifactPaths)
-
-                    var sized: [ProjectCacheArtifact] = []
-                    for row in rows {
-                        let pathKey = row.path.standardizedFileURL.path
-                        let bytes = sizesByPath[pathKey] ?? 0
-                        let modified = FolderSizing.contentModificationDate(at: row.path)
-                        sized.append(
-                            ProjectCacheArtifact(
-                                kind: row.kind,
-                                path: row.path,
-                                projectRoot: row.projectRoot,
-                                sizeBytes: bytes,
-                                lastModified: modified,
-                                isSelected: false,
-                                safetyInfo: row.safetyInfo,
-                                reinstallSafety: row.reinstallSafety,
-                                gitStatus: .unknown
-                            )
-                        )
-                    }
-                    sized.sort { $0.sizeBytes > $1.sizeBytes }
-
-                    let staleDays = DevToolsStalenessOption.currentThresholdDays()
-                    let now = Date()
-                    let staleArtifacts: [ProjectCacheArtifact]
-                    if staleDays == DevToolsStalenessOption.showAll.rawValue {
-                        staleArtifacts = sized
-                    } else {
-                        staleArtifacts = sized.filter {
-                            Self.daysBetween($0.lastModified, now) >= staleDays
-                        }
-                    }
-
-                    guard !staleArtifacts.isEmpty else { return (nil, rows.count) }
-
-                    return (
-                        ProjectGroup(
-                            displayName: rootURL.lastPathComponent,
-                            rootPath: rootURL,
-                            inferredTypes: types,
-                            artifacts: staleArtifacts
-                        ),
-                        rows.count
-                    )
+            while inFlight < Self.maxConcurrentProjectSizings, let next = pending.next() {
+                group.addTask { [next] in
+                    DevScanner.sizeProjectGroup(rootURL: next.0, types: next.1)
                 }
+                inFlight += 1
             }
 
             var groups: [ProjectGroup] = []
             var artifactsSized = 0
-            for await result in group {
+            while let result = await group.next() {
                 artifactsSized += result.1
                 if let g = result.0 {
                     groups.append(g)
                     continuation?.yield(.projectGroupFound(g))
                 }
+                if Task.isCancelled { continue }
+                if let next = pending.next() {
+                    group.addTask { [next] in
+                        DevScanner.sizeProjectGroup(rootURL: next.0, types: next.1)
+                    }
+                }
             }
             return (groups, artifactsSized)
         }
+    }
+
+    /// How many project roots may be sized at once. See `buildProjectGroups`.
+    private static let maxConcurrentProjectSizings = 4
+
+    private nonisolated static func sizeProjectGroup(
+        rootURL: URL,
+        types: [ProjectType]
+    ) -> (ProjectGroup?, Int) {
+        let rows = DevScanner.collectArtifacts(projectRoot: rootURL, types: types)
+        guard !rows.isEmpty else { return (nil, 0) }
+
+        let artifactPaths = rows.map(\.path)
+        let sizesByPath = FolderSizing.directorySizes(at: artifactPaths)
+
+        var sized: [ProjectCacheArtifact] = []
+        for row in rows {
+            let pathKey = row.path.standardizedFileURL.path
+            let bytes = sizesByPath[pathKey] ?? 0
+            let modified = FolderSizing.contentModificationDate(at: row.path)
+            sized.append(
+                ProjectCacheArtifact(
+                    kind: row.kind,
+                    path: row.path,
+                    projectRoot: row.projectRoot,
+                    sizeBytes: bytes,
+                    lastModified: modified,
+                    isSelected: false,
+                    safetyInfo: row.safetyInfo,
+                    reinstallSafety: row.reinstallSafety,
+                    gitStatus: .unknown
+                )
+            )
+        }
+        sized.sort { $0.sizeBytes > $1.sizeBytes }
+
+        let staleDays = DevToolsStalenessOption.currentThresholdDays()
+        let now = Date()
+        let staleArtifacts: [ProjectCacheArtifact]
+        if staleDays == DevToolsStalenessOption.showAll.rawValue {
+            staleArtifacts = sized
+        } else {
+            staleArtifacts = sized.filter {
+                Self.daysBetween($0.lastModified, now) >= staleDays
+            }
+        }
+
+        guard !staleArtifacts.isEmpty else { return (nil, rows.count) }
+
+        return (
+            ProjectGroup(
+                displayName: rootURL.lastPathComponent,
+                rootPath: rootURL,
+                inferredTypes: types,
+                artifacts: staleArtifacts
+            ),
+            rows.count
+        )
     }
 
     private struct SizedArtifactIntermediate {

--- a/purge/Services/DevScanner.swift
+++ b/purge/Services/DevScanner.swift
@@ -9,7 +9,9 @@ enum DeveloperScanEvent {
     case simulatorSizeResolved(id: UUID, sizeBytes: Int64)
 }
 
-final class DevScanner {
+/// `nonisolated` for the same reason as `CacheScanner` — a probe confirmed
+/// `runDeveloperScan` was executing on the main thread despite `Task.detached`.
+nonisolated final class DevScanner {
     private struct DevToolSizeJob {
         let toolID: String
         let toolLabel: String

--- a/purge/Services/LargeFileScanner.swift
+++ b/purge/Services/LargeFileScanner.swift
@@ -1,6 +1,13 @@
 import Foundation
 
-final class LargeFileScanner {
+/// `nonisolated` is load-bearing, not tidiness. The project builds with
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so without it this type — and the
+/// `static run` below — are implicitly main-actor isolated, and the `Task.detached`
+/// in `scanStream` immediately hops *back* to the main actor. A probe confirmed
+/// `run` executing with `Thread.isMainThread == true`, i.e. the entire
+/// home-directory walk was blocking the UI; it measured as a ~1.15s freeze on
+/// first switch to the Large Files tab.
+nonisolated final class LargeFileScanner {
     func scanStream(minBytes: Int64, staleDays: Int) -> AsyncStream<LargeFile> {
         AsyncStream { continuation in
             let task = Task.detached(priority: .userInitiated) {

--- a/purge/Services/PurgeStore.swift
+++ b/purge/Services/PurgeStore.swift
@@ -216,6 +216,17 @@ final class PurgeStore: ObservableObject {
         static let flushThreshold = 100
     }
 
+    /// The scan-flush cadence in seconds, derived from `ScanCoalesce.flushInterval`.
+    ///
+    /// The sidebar hero rolls its digits with a linear animation matched to this beat so
+    /// each tick hands off to the next instead of being retargeted mid-curve. Derived
+    /// rather than restated so retuning the interval cannot silently desynchronise the
+    /// animation from the publish rate.
+    static let scanFlushIntervalSeconds: Double = {
+        let components = ScanCoalesce.flushInterval.components
+        return Double(components.seconds) + Double(components.attoseconds) * 1e-18
+    }()
+
     /// Cancels stale async simulator sizing when a new dev scan starts.
     private var simulatorSizingGeneration = 0
     private var scanGeneration = 0
@@ -370,10 +381,7 @@ final class PurgeStore: ObservableObject {
     }
 
     func isVisuallyRemovedBySafeCleanup(_ tool: DevTool) -> Bool {
-        guard !interactiveSafeCleanupTargetPaths.isEmpty else { return false }
-        return isVisuallyRemovedBySafeCleanup(
-            paths: tool.paths.map { $0.standardizedFileURL.path }
-        )
+        isVisuallyRemovedBySafeCleanup(paths: tool.standardizedPaths)
     }
 
     func isVisuallyRemovedBySafeCleanup(_ artifact: ProjectCacheArtifact) -> Bool {

--- a/purge/Services/PurgeStore.swift
+++ b/purge/Services/PurgeStore.swift
@@ -111,11 +111,35 @@ final class PurgeStore: ObservableObject {
     }
 
     @Published var selectedTab: Tab = .appCaches
-    @Published var cacheItems: [CacheItem] = []
-    @Published var devTools: [DevTool] = []
+    @Published var cacheItems: [CacheItem] = [] {
+        didSet {
+            invalidateSafeCleanupSummary()
+            cacheItemsRevision &+= 1
+        }
+    }
+    /// Cheap stand-in for "the set of cache rows changed", for use as an
+    /// `.animation(_:value:)` key — see `largeFilesRevision` for the same pattern.
+    @Published private(set) var cacheItemsRevision = 0
+    @Published var devTools: [DevTool] = [] {
+        didSet {
+            invalidateSafeCleanupSummary()
+            devToolsRevision &+= 1
+        }
+    }
+    @Published private(set) var devToolsRevision = 0
     @Published var simulatorDevices: [SimulatorDevice] = []
-    @Published var projectGroups: [ProjectGroup] = []
-    @Published var largeFiles: [LargeFile] = []
+    @Published var projectGroups: [ProjectGroup] = [] {
+        didSet { invalidateSafeCleanupSummary() }
+    }
+    @Published var largeFiles: [LargeFile] = [] {
+        didSet { largeFilesRevision &+= 1 }
+    }
+    /// Cheap stand-in for "the set of large-file rows changed", for use as an
+    /// `.animation(_:value:)` key. The list previously animated on
+    /// `largeFiles.map(\.id)`, which allocated and then compared an array of every
+    /// row's path string on each body evaluation; this is O(1) and, being driven from
+    /// `didSet`, also catches in-place edits that an id list would miss.
+    @Published private(set) var largeFilesRevision = 0
     /// Large-file selection lives in its own observable object (NOT @Published on the
     /// store) so toggling a row does not fire the store's objectWillChange and thus
     /// does not re-render the results List container — a List re-render reverts the
@@ -127,7 +151,9 @@ final class PurgeStore: ObservableObject {
     @Published var isScanningLargeFiles = false
     @Published var showLargeFileDeletionSheet = false
     /// Best-effort git status keyed by standardized tool path (`URL.path`).
-    @Published private(set) var devToolRepoStatusByPath: [String: GitWorktreeStatus] = [:]
+    @Published private(set) var devToolRepoStatusByPath: [String: GitWorktreeStatus] = [:] {
+        didSet { invalidateSafeCleanupSummary() }
+    }
     @Published var isScanningGeneral = false
     @Published var isScanningDeveloper = false
     @Published private(set) var isScanningProjects = false
@@ -183,7 +209,10 @@ final class PurgeStore: ObservableObject {
     private let gitChecker = GitStatusChecker()
 
     private enum ScanCoalesce {
-        static let debounceNanoseconds: UInt64 = 150_000_000
+        /// One publish every ~8 frames. Fast enough that the count reads as live,
+        /// slow enough that each tick's `.numericText()` roll finishes before the
+        /// next value lands rather than being retargeted mid-flight.
+        static let flushInterval: Duration = .milliseconds(140)
         static let flushThreshold = 100
     }
 
@@ -257,7 +286,30 @@ final class PurgeStore: ObservableObject {
         }
     }
 
+    /// Memoised `safeCleanupSummary`, cleared by `didSet` on each of the four inputs it
+    /// reads. Invalidating from `didSet` rather than at the call sites means subscript
+    /// writes (`cacheItems[i].safetyInfo = …`) invalidate too, so no mutation path can
+    /// silently leave a stale total behind.
+    private var cachedSafeCleanupSummary: SafeCleanupSummary?
+
+    fileprivate func invalidateSafeCleanupSummary() {
+        cachedSafeCleanupSummary = nil
+    }
+
+    /// The sidebar hero, the Clean button title, and the footnote all read this, several
+    /// times each per render, and the render re-runs on every scan flush. Recomputing was
+    /// a full sweep of every cache item, dev tool, and project artifact each time —
+    /// including a `standardizedFileURL` per dev-tool path, which is the expensive part.
     var safeCleanupSummary: SafeCleanupSummary {
+        if let cached = cachedSafeCleanupSummary {
+            return cached
+        }
+        let summary = computeSafeCleanupSummary()
+        cachedSafeCleanupSummary = summary
+        return summary
+    }
+
+    private func computeSafeCleanupSummary() -> SafeCleanupSummary {
         var summary = SafeCleanupSummary()
         summary.appCacheBytes = cacheItems.reduce(Int64(0)) { total, item in
             guard item.safetyInfo.level == .safe,
@@ -289,6 +341,46 @@ final class PurgeStore: ObservableObject {
 
     var isInteractiveSafeCleanupInProgress: Bool {
         !interactiveSafeCleanupTargetPaths.isEmpty && interactiveSafeCleanupMovedToTrashBytes == nil
+    }
+
+    // MARK: - Interactive safe-cleanup row hiding
+
+    /// Whether a row should be hidden because an interactive safe cleanup already
+    /// removed everything it targeted.
+    ///
+    /// The leading `isEmpty` check is the important part. These helpers are called once
+    /// per item inside the views' `visibleIndices`, which SwiftUI re-evaluates many times
+    /// per render — and the old per-view copies standardized every row path first, which
+    /// stats the filesystem. Profiling attributed a large share of the tab-switch stall
+    /// to exactly that. No cleanup is running for the overwhelming majority of renders,
+    /// and when the target set is empty the answer is `false` for every row, so the
+    /// guard skips the whole scan.
+    func isVisuallyRemovedBySafeCleanup(paths: [String]) -> Bool {
+        guard !interactiveSafeCleanupTargetPaths.isEmpty else { return false }
+        var sawTarget = false
+        for path in paths where interactiveSafeCleanupTargetPaths.contains(path) {
+            sawTarget = true
+            if !interactiveSafeCleanupRemovedPaths.contains(path) { return false }
+        }
+        return sawTarget
+    }
+
+    func isVisuallyRemovedBySafeCleanup(_ item: CacheItem) -> Bool {
+        isVisuallyRemovedBySafeCleanup(paths: item.standardizedPaths)
+    }
+
+    func isVisuallyRemovedBySafeCleanup(_ tool: DevTool) -> Bool {
+        guard !interactiveSafeCleanupTargetPaths.isEmpty else { return false }
+        return isVisuallyRemovedBySafeCleanup(
+            paths: tool.paths.map { $0.standardizedFileURL.path }
+        )
+    }
+
+    func isVisuallyRemovedBySafeCleanup(_ artifact: ProjectCacheArtifact) -> Bool {
+        guard !interactiveSafeCleanupTargetPaths.isEmpty else { return false }
+        let path = artifact.path.standardizedFileURL.path
+        return interactiveSafeCleanupTargetPaths.contains(path)
+            && interactiveSafeCleanupRemovedPaths.contains(path)
     }
 
     /// `true` while the cleanup overlay is in its cleaning phase — used to gate
@@ -939,6 +1031,25 @@ final class PurgeStore: ObservableObject {
         }
     }
 
+    /// Runs the access probe off the main actor.
+    ///
+    /// The probe lists `~/Library/Safari`, `~/Library/Containers`, and
+    /// `~/Library/Application Support`; on a real machine those hold hundreds of
+    /// entries, so it is genuine filesystem work. The onboarding permissions step polls
+    /// it once a second while on screen, and running it inline on the main actor showed
+    /// up in profiles as a periodic hitch during exactly the phase users described as
+    /// laggy. Publishing the result is left to the caller so it can animate the change.
+    nonisolated func probeFullDiskAccess() async -> Bool {
+        await Task.detached(priority: .utility) {
+            PermissionChecker().hasFullDiskAccess()
+        }.value
+    }
+
+    func applyFullDiskAccess(_ granted: Bool) {
+        guard hasFullDiskAccess != granted else { return }
+        hasFullDiskAccess = granted
+    }
+
     func refreshPermission() {
         hasFullDiskAccess = PermissionChecker().hasFullDiskAccess()
     }
@@ -1545,10 +1656,18 @@ final class PurgeStore: ObservableObject {
 
     // MARK: - Scan stream coalescing
 
-    private final class CacheScanCoalesceBuffers {
+    /// Shared state for the scan flush throttle. See `scheduleFlush(_:generation:flush:)`.
+    private protocol ScanCoalesceBuffer: AnyObject {
+        var debounceTask: Task<Void, Never>? { get set }
+        var lastFlushAt: ContinuousClock.Instant? { get set }
+        var eventCount: Int { get }
+    }
+
+    private final class CacheScanCoalesceBuffers: ScanCoalesceBuffer {
         var pendingFound: [CacheItem] = []
         var pendingSizeUpdates: [String: (sizeBytes: Int64, lastModified: Date)] = [:]
         var debounceTask: Task<Void, Never>?
+        var lastFlushAt: ContinuousClock.Instant?
 
         var eventCount: Int { pendingFound.count + pendingSizeUpdates.count }
 
@@ -1574,12 +1693,13 @@ final class PurgeStore: ObservableObject {
         let lastModified: Date
     }
 
-    private final class DeveloperScanCoalesceBuffers {
+    private final class DeveloperScanCoalesceBuffers: ScanCoalesceBuffer {
         var pendingTools: [String: DevTool] = [:]
         var pendingToolSizes: [String: DevToolSizeUpdate] = [:]
         var pendingSimulators: [UUID: SimulatorDevice] = [:]
         var pendingSimulatorSizes: [UUID: Int64] = [:]
         var debounceTask: Task<Void, Never>?
+        var lastFlushAt: ContinuousClock.Instant?
 
         var eventCount: Int {
             pendingTools.count + pendingToolSizes.count + pendingSimulators.count + pendingSimulatorSizes.count
@@ -1625,9 +1745,10 @@ final class PurgeStore: ObservableObject {
         }
     }
 
-    private final class ProjectGroupCoalesceBuffers {
+    private final class ProjectGroupCoalesceBuffers: ScanCoalesceBuffer {
         var pendingGroups: [String: ProjectGroup] = [:]
         var debounceTask: Task<Void, Never>?
+        var lastFlushAt: ContinuousClock.Instant?
 
         var eventCount: Int { pendingGroups.count }
 
@@ -1642,20 +1763,53 @@ final class PurgeStore: ObservableObject {
         }
     }
 
-    private func scheduleCacheScanFlush(coalesce: CacheScanCoalesceBuffers, generation: Int) {
+    /// Publishes buffered scan events on a steady cadence.
+    ///
+    /// This is a throttle, not a reset-debounce, and the distinction is the whole point.
+    /// The previous version cancelled and re-armed the timer on every event, so a scan
+    /// producing events faster than the interval never reached the deadline — the only
+    /// thing that ever fired was the event-count threshold. Flushes therefore landed in
+    /// irregular clumps (a burst of 100 events could publish in 20ms or in two seconds),
+    /// and the sidebar total lurched and stuttered between them instead of counting up.
+    ///
+    /// Anchoring the next deadline to the *previous flush* rather than to the latest
+    /// event keeps updates on a fixed beat whatever the event rate, which is what lets
+    /// the hero figure animate smoothly.
+    private func scheduleFlush<Buffer: ScanCoalesceBuffer>(
+        _ coalesce: Buffer,
+        generation: Int,
+        flush: @escaping (Buffer) -> Void
+    ) {
+        // Backstop: a very fast producer still yields to the UI every `flushThreshold`
+        // events rather than letting the buffer grow unbounded until the next tick.
         if coalesce.eventCount >= ScanCoalesce.flushThreshold {
             coalesce.debounceTask?.cancel()
             coalesce.debounceTask = nil
-            flushCacheScanBuffers(coalesce: coalesce, animate: false)
+            coalesce.lastFlushAt = .now
+            flush(coalesce)
             return
         }
 
-        coalesce.debounceTask?.cancel()
+        // A tick is already queued for this window — it will pick up everything
+        // buffered since. Re-arming here is exactly the bug described above.
+        guard coalesce.debounceTask == nil else { return }
+
+        let earliest = (coalesce.lastFlushAt ?? .now) + ScanCoalesce.flushInterval
+        let delay = max(.zero, ContinuousClock.Instant.now.duration(to: earliest))
+
         coalesce.debounceTask = Task { @MainActor [weak self, weak coalesce] in
-            try? await Task.sleep(nanoseconds: ScanCoalesce.debounceNanoseconds)
+            try? await Task.sleep(for: delay)
             guard let self, let coalesce, !Task.isCancelled else { return }
+            coalesce.debounceTask = nil
             guard self.scanGeneration == generation else { return }
-            self.flushCacheScanBuffers(coalesce: coalesce, animate: false)
+            coalesce.lastFlushAt = .now
+            flush(coalesce)
+        }
+    }
+
+    private func scheduleCacheScanFlush(coalesce: CacheScanCoalesceBuffers, generation: Int) {
+        scheduleFlush(coalesce, generation: generation) { [weak self] buffer in
+            self?.flushCacheScanBuffers(coalesce: buffer, animate: false)
         }
     }
 
@@ -1773,19 +1927,8 @@ final class PurgeStore: ObservableObject {
     }
 
     private func scheduleDeveloperScanFlush(coalesce: DeveloperScanCoalesceBuffers, generation: Int) {
-        if coalesce.eventCount >= ScanCoalesce.flushThreshold {
-            coalesce.debounceTask?.cancel()
-            coalesce.debounceTask = nil
-            flushDeveloperScanBuffers(coalesce: coalesce, animate: false)
-            return
-        }
-
-        coalesce.debounceTask?.cancel()
-        coalesce.debounceTask = Task { @MainActor [weak self, weak coalesce] in
-            try? await Task.sleep(nanoseconds: ScanCoalesce.debounceNanoseconds)
-            guard let self, let coalesce, !Task.isCancelled else { return }
-            guard self.scanGeneration == generation else { return }
-            self.flushDeveloperScanBuffers(coalesce: coalesce, animate: false)
+        scheduleFlush(coalesce, generation: generation) { [weak self] buffer in
+            self?.flushDeveloperScanBuffers(coalesce: buffer, animate: false)
         }
     }
 
@@ -1892,19 +2035,8 @@ final class PurgeStore: ObservableObject {
     }
 
     private func scheduleProjectGroupFlush(coalesce: ProjectGroupCoalesceBuffers, generation: Int) {
-        if coalesce.eventCount >= ScanCoalesce.flushThreshold {
-            coalesce.debounceTask?.cancel()
-            coalesce.debounceTask = nil
-            flushProjectGroupBuffers(coalesce: coalesce, animate: false)
-            return
-        }
-
-        coalesce.debounceTask?.cancel()
-        coalesce.debounceTask = Task { @MainActor [weak self, weak coalesce] in
-            try? await Task.sleep(nanoseconds: ScanCoalesce.debounceNanoseconds)
-            guard let self, let coalesce, !Task.isCancelled else { return }
-            guard self.scanGeneration == generation else { return }
-            self.flushProjectGroupBuffers(coalesce: coalesce, animate: false)
+        scheduleFlush(coalesce, generation: generation) { [weak self] buffer in
+            self?.flushProjectGroupBuffers(coalesce: buffer, animate: false)
         }
     }
 
@@ -1940,8 +2072,11 @@ final class PurgeStore: ObservableObject {
         }
     }
 
+    /// Read once per row per render, so it must not touch the filesystem — the item
+    /// already carries its standardized paths.
     func cacheItemHasPendingSize(_ item: CacheItem) -> Bool {
-        item.locations.contains { pendingCacheSizePaths.contains($0.path.standardizedFileURL.path) }
+        guard !pendingCacheSizePaths.isEmpty else { return false }
+        return item.standardizedPaths.contains { pendingCacheSizePaths.contains($0) }
     }
 
     func projectArtifactHasPendingSize(_ artifact: ProjectCacheArtifact) -> Bool {

--- a/purge/Utilities/ByteFormatter.swift
+++ b/purge/Utilities/ByteFormatter.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-func formatBytes(_ bytes: Int64) -> String {
+nonisolated func formatBytes(_ bytes: Int64) -> String {
     guard bytes > 0 else { return "0 bytes" }
 
     let formatter = ByteCountFormatter()
@@ -38,7 +38,7 @@ func formatStorageBytes(_ bytes: Int64) -> String {
 /// `formatBytes` rounds to nearest, which would turn 1.29 GB into "1.3 GB" and quietly
 /// promise more than exists. An "up to" figure has to under-promise by construction: the
 /// measured outcome must always be able to meet or beat it.
-func formatBytesRoundedDown(_ bytes: Int64) -> String {
+nonisolated func formatBytesRoundedDown(_ bytes: Int64) -> String {
     guard bytes > 0 else { return "0 bytes" }
 
     let units: [(threshold: Int64, suffix: String)] = [

--- a/purge/Utilities/FilePathDisplay.swift
+++ b/purge/Utilities/FilePathDisplay.swift
@@ -1,7 +1,7 @@
 import AppKit
 import Foundation
 
-func displayDirectoryPath(for directoryURL: URL) -> String {
+nonisolated func displayDirectoryPath(for directoryURL: URL) -> String {
     let directory = directoryURL.standardizedFileURL
     let path = directory.path
     let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
@@ -12,7 +12,7 @@ func displayDirectoryPath(for directoryURL: URL) -> String {
 }
 
 /// Friendly application name for a bundle identifier, or `nil` if no installed app matches.
-func appDisplayName(forBundleID bundleID: String) -> String? {
+nonisolated func appDisplayName(forBundleID bundleID: String) -> String? {
     guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else {
         return nil
     }

--- a/purge/Utilities/FolderSizing.swift
+++ b/purge/Utilities/FolderSizing.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Shared folder sizing so scans can call this from background tasks without hopping through `MainActor`.
 enum FolderSizing {
-    static let duChunkSize = 64
+    nonisolated static let duChunkSize = 64
     private static let maxConcurrentDuChunks = 10
 
     /// A chunk walking a deep tree can legitimately take minutes, so this is loose. It exists

--- a/purge/Utilities/FolderSizing.swift
+++ b/purge/Utilities/FolderSizing.swift
@@ -13,6 +13,9 @@ enum FolderSizing {
     /// total, and the scanners legitimately call this concurrently.
     private nonisolated static let duChunkLimiter = DispatchSemaphore(value: maxConcurrentDuChunks)
 
+    /// How often a caller queued on `duChunkLimiter` re-checks for cancellation.
+    private nonisolated static let limiterPollInterval: DispatchTimeInterval = .milliseconds(100)
+
     /// A chunk walking a deep tree can legitimately take minutes, so this is loose. It exists
     /// only so a `du` that never returns cannot wedge the scan permanently.
     private static let duChunkTimeout: TimeInterval = 300
@@ -63,7 +66,25 @@ enum FolderSizing {
 
         for chunk in chunks {
             if Task.isCancelled { break }
-            duChunkLimiter.wait()
+
+            // Timed acquisition, not `wait()`. The limiter is process-wide, so this can be
+            // queued behind a permit held by an *unrelated* scan whose chunk runs all the
+            // way to `duChunkTimeout`. An indefinite wait would keep a cancelled scan
+            // parked here for that long — on a cooperative-pool thread, which is the
+            // resource the bounded fan-out in `DevScanner.buildProjectGroups` exists to
+            // protect.
+            var acquired = false
+            while !acquired && !Task.isCancelled {
+                acquired = duChunkLimiter.wait(timeout: .now() + limiterPollInterval) == .success
+            }
+            guard acquired else { break }
+            // Cancelled between acquiring and dispatching: the permit must go back, or a
+            // process-wide slot is lost for the lifetime of the app.
+            guard !Task.isCancelled else {
+                duChunkLimiter.signal()
+                break
+            }
+
             group.enter()
             DispatchQueue.global(qos: .utility).async {
                 defer {

--- a/purge/Utilities/FolderSizing.swift
+++ b/purge/Utilities/FolderSizing.swift
@@ -5,6 +5,14 @@ enum FolderSizing {
     nonisolated static let duChunkSize = 64
     private static let maxConcurrentDuChunks = 10
 
+    /// Process-wide, deliberately **not** per call.
+    ///
+    /// A per-call semaphore caps one `directorySizes` invocation at ten `du` processes but
+    /// says nothing about how many invocations run at once — N concurrent callers meant up
+    /// to 10N subprocesses. `du` is I/O-bound on a single disk, so the useful limit is a
+    /// total, and the scanners legitimately call this concurrently.
+    private nonisolated static let duChunkLimiter = DispatchSemaphore(value: maxConcurrentDuChunks)
+
     /// A chunk walking a deep tree can legitimately take minutes, so this is loose. It exists
     /// only so a `du` that never returns cannot wedge the scan permanently.
     private static let duChunkTimeout: TimeInterval = 300
@@ -51,16 +59,15 @@ enum FolderSizing {
 
         var result: [String: Int64] = [:]
         let lock = NSLock()
-        let semaphore = DispatchSemaphore(value: maxConcurrentDuChunks)
         let group = DispatchGroup()
 
         for chunk in chunks {
             if Task.isCancelled { break }
-            semaphore.wait()
+            duChunkLimiter.wait()
             group.enter()
             DispatchQueue.global(qos: .utility).async {
                 defer {
-                    semaphore.signal()
+                    duChunkLimiter.signal()
                     group.leave()
                 }
                 let partial = directorySizesForChunk(chunk)

--- a/purge/Utilities/ScanPhaseTiming.swift
+++ b/purge/Utilities/ScanPhaseTiming.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Temporary scan instrumentation — logs lines prefixed with `PURGE-TIMING:` for profiling.
-enum ScanPhaseTiming {
+nonisolated enum ScanPhaseTiming {
     static func log(_ message: String) {
         #if DEBUG
         print("PURGE-TIMING: \(message)")

--- a/purge/Views/AppRootView.swift
+++ b/purge/Views/AppRootView.swift
@@ -24,13 +24,29 @@ struct AppRootView: View {
     (hasCompletedOnboarding || isMainAppRevealed || reduceMotion) && !showsAccessGate
   }
 
+  /// Whether `ContentView` should exist at all. Distinct from `showsMainApp`, which only
+  /// controls its opacity during the onboarding hand-off.
+  private var showsMainAppContent: Bool {
+    hasCompletedOnboarding || isOnboardingExitingToHome
+  }
+
   var body: some View {
     ZStack {
-      ContentView(isLifecycleActive: hasCompletedOnboarding && store.hasFullDiskAccess)
-        .opacity(showsMainApp ? 1 : 0)
-        .blur(radius: showsMainApp ? 0 : OnboardingTransitions.dismissBlurRadius)
-        .allowsHitTesting(showsMainApp)
-        .accessibilityHidden(!showsMainApp)
+      // Mounted only once it is about to be needed. Keeping it in the hierarchy for the
+      // whole of onboarding meant the full main app — including the App Caches list and
+      // every one of its rows — was laid out and rendered behind the onboarding overlay
+      // at `opacity(0)`, competing with the step transitions for the main thread.
+      // Profiling the onboarding flow showed `ScanResultRow` and
+      // `AppCachesView.cacheResultsListContent` bodies running while onboarding was on
+      // screen. The pre-mount before the reveal is preserved: `isOnboardingExitingToHome`
+      // flips first, and `revealMainAppAfterMount` already waits 120ms before fading in.
+      if showsMainAppContent {
+        ContentView(isLifecycleActive: hasCompletedOnboarding && store.hasFullDiskAccess)
+          .opacity(showsMainApp ? 1 : 0)
+          .blur(radius: showsMainApp ? 0 : OnboardingTransitions.dismissBlurRadius)
+          .allowsHitTesting(showsMainApp)
+          .accessibilityHidden(!showsMainApp)
+      }
       if !hasCompletedOnboarding {
         OnboardingFlowView(
           hasCompletedOnboarding: $hasCompletedOnboarding,

--- a/purge/Views/DevModeView.swift
+++ b/purge/Views/DevModeView.swift
@@ -99,7 +99,7 @@ struct DevToolsView<PageHeader: View>: View {
 
     private func groupHasVisibleArtifacts(_ group: ProjectGroup) -> Bool {
         group.artifacts.contains {
-            artifactVisible($0.safetyInfo) && !isVisuallyRemovedBySafeCleanup($0)
+            artifactVisible($0.safetyInfo) && !store.isVisuallyRemovedBySafeCleanup($0)
         }
     }
 
@@ -137,7 +137,7 @@ struct DevToolsView<PageHeader: View>: View {
     private func standardToolVisible(_ index: Int) -> Bool {
         guard store.devTools[index].isDetected else { return false }
         return artifactVisible(store.devTools[index].safetyInfo)
-            && !isVisuallyRemovedBySafeCleanup(store.devTools[index])
+            && !store.isVisuallyRemovedBySafeCleanup(store.devTools[index])
     }
 
     private func filteredStandardToolIndices() -> [Int] {
@@ -282,7 +282,7 @@ struct DevToolsView<PageHeader: View>: View {
         let g = store.projectGroups[gi]
         let raw = g.artifacts.indices.filter {
             artifactVisible(g.artifacts[$0].safetyInfo)
-                && !isVisuallyRemovedBySafeCleanup(g.artifacts[$0])
+                && !store.isVisuallyRemovedBySafeCleanup(g.artifacts[$0])
         }
         switch currentSort {
         case .sizeDesc:
@@ -319,7 +319,7 @@ struct DevToolsView<PageHeader: View>: View {
             for ai in store.projectGroups[gi].artifacts.indices {
                 let art = store.projectGroups[gi].artifacts[ai]
                 guard artifactVisible(art.safetyInfo) else { continue }
-                guard !isVisuallyRemovedBySafeCleanup(art) else { continue }
+                guard !store.isVisuallyRemovedBySafeCleanup(art) else { continue }
                 guard isEligibleForManualBulkSelection(art.safetyInfo) else { continue }
                 pairs.append((gi, ai))
             }
@@ -473,7 +473,7 @@ struct DevToolsView<PageHeader: View>: View {
         for gi in filteredProjectGroupIndices() {
             let g = store.projectGroups[gi]
             for ai in g.artifacts.indices where artifactVisible(g.artifacts[ai].safetyInfo)
-                && !isVisuallyRemovedBySafeCleanup(g.artifacts[ai]) {
+                && !store.isVisuallyRemovedBySafeCleanup(g.artifacts[ai]) {
                 sum += g.artifacts[ai].sizeBytes
             }
         }
@@ -840,19 +840,6 @@ struct DevToolsView<PageHeader: View>: View {
                 insertion: .identity,
                 removal: .opacity.combined(with: .move(edge: .trailing))
             )
-    }
-
-    private func isVisuallyRemovedBySafeCleanup(_ tool: DevTool) -> Bool {
-        let rowPaths = Set(tool.paths.map { $0.standardizedFileURL.path })
-        let targetedPaths = rowPaths.intersection(store.interactiveSafeCleanupTargetPaths)
-        guard !targetedPaths.isEmpty else { return false }
-        return targetedPaths.isSubset(of: store.interactiveSafeCleanupRemovedPaths)
-    }
-
-    private func isVisuallyRemovedBySafeCleanup(_ artifact: ProjectCacheArtifact) -> Bool {
-        let path = artifact.path.standardizedFileURL.path
-        return store.interactiveSafeCleanupTargetPaths.contains(path)
-            && store.interactiveSafeCleanupRemovedPaths.contains(path)
     }
 
     private var developerProjectsSectionHeader: some View {

--- a/purge/Views/GeneralModeView.swift
+++ b/purge/Views/GeneralModeView.swift
@@ -52,128 +52,140 @@ struct AppCachesView<PageHeader: View>: View {
         )
     }
 
-    private var visibleIndices: [Int] {
-        items.indices.filter {
-            currentSafetyFilter.matches(items[$0].safetyInfo) && !isVisuallyRemovedBySafeCleanup(items[$0])
+    /// Everything the render needs that is derived from `items`, computed in one pass.
+    ///
+    /// Previously each of these was a computed property that re-derived `visibleIndices`
+    /// from scratch, and eight separate call sites read one of them per render — so a
+    /// single body evaluation walked the full item list eight times over. Profiling the
+    /// tab-switch stall showed `visibleIndices` reached from `showsListContent`,
+    /// `selectAllState`, `selectedInScopeCount`, `selectedInScopeBytes`,
+    /// `sortedVisibleIndices()`, and the select-all row, all in the same pass.
+    ///
+    /// Selection-dependent numbers deliberately stay out of here: they are read inside
+    /// `ScanSelectionScope`, which re-renders on selection changes *without* re-rendering
+    /// the container, and folding them in would defeat that.
+    struct ListPlan {
+        var sortedVisibleIndices: [Int] = []
+        var visibleCount = 0
+        var visibleTotalBytes: Int64 = 0
+        var displayableCount = 0
+        var displayableTotalBytes: Int64 = 0
+        var chipCounts: [SafetyFilter: Int] = [:]
+
+        var isEmpty: Bool { sortedVisibleIndices.isEmpty }
+    }
+
+    private func makeListPlan() -> ListPlan {
+        var plan = ListPlan()
+        guard !items.isEmpty else { return plan }
+
+        let filter = currentSafetyFilter
+        let hidesRemovedRows = !store.interactiveSafeCleanupTargetPaths.isEmpty
+        var chips: [SafetyFilter: Int] = [:]
+        var visible: [Int] = []
+        visible.reserveCapacity(items.count)
+
+        for index in items.indices {
+            let item = items[index]
+            let info = item.safetyInfo
+
+            for candidate in SafetyFilter.allCases where candidate.matches(info) {
+                chips[candidate, default: 0] += 1
+            }
+
+            if SafetyFilter.all.matches(info) {
+                plan.displayableCount += 1
+                plan.displayableTotalBytes += item.sizeBytes
+            }
+
+            guard filter.matches(info) else { continue }
+            if hidesRemovedRows, store.isVisuallyRemovedBySafeCleanup(item) { continue }
+            visible.append(index)
+            plan.visibleTotalBytes += item.sizeBytes
         }
-    }
 
-    private var eligibleSelectIndices: [Int] {
-        visibleIndices
-    }
+        plan.chipCounts = chips
+        plan.visibleCount = visible.count
 
-    private func sortedVisibleIndices() -> [Int] {
-        let base = visibleIndices
         switch SortOption(rawValue: sortRaw) ?? .sizeDesc {
         case .sizeDesc:
-            return base.sorted { items[$0].sizeBytes > items[$1].sizeBytes }
+            visible.sort { items[$0].sizeBytes > items[$1].sizeBytes }
         case .sizeAsc:
-            return base.sorted { items[$0].sizeBytes < items[$1].sizeBytes }
+            visible.sort { items[$0].sizeBytes < items[$1].sizeBytes }
         case .dateNewest:
-            return base.sorted { items[$0].lastModified > items[$1].lastModified }
+            visible.sort { items[$0].lastModified > items[$1].lastModified }
         case .dateOldest:
-            return base.sorted { items[$0].lastModified < items[$1].lastModified }
+            visible.sort { items[$0].lastModified < items[$1].lastModified }
         case .nameAZ:
-            return base.sorted { items[$0].appName.localizedCaseInsensitiveCompare(items[$1].appName) == .orderedAscending }
+            visible.sort { items[$0].appName.localizedCaseInsensitiveCompare(items[$1].appName) == .orderedAscending }
         }
+        plan.sortedVisibleIndices = visible
+        return plan
     }
 
-    private var selectAllState: SelectAllTriState {
-        let ix = eligibleSelectIndices
+    private func selectAllState(plan: ListPlan) -> SelectAllTriState {
+        let ix = plan.sortedVisibleIndices
         guard !ix.isEmpty else { return .none }
         let selectedIDs = store.scanSelection.cacheIDs
-        let selected = ix.filter { selectedIDs.contains(items[$0].id) }
-        if selected.count == ix.count { return .all }
-        if selected.isEmpty { return .none }
+        var selected = 0
+        for index in ix where selectedIDs.contains(items[index].id) { selected += 1 }
+        if selected == ix.count { return .all }
+        if selected == 0 { return .none }
         return .mixed
     }
 
-    private var chipCounts: [SafetyFilter: Int] {
-        var d: [SafetyFilter: Int] = [:]
-        for filter in SafetyFilter.allCases {
-            d[filter] = items.filter { filter.matches($0.safetyInfo) }.count
+    private func selectedInScope(plan: ListPlan) -> (count: Int, bytes: Int64) {
+        let selectedIDs = store.scanSelection.cacheIDs
+        var count = 0
+        var bytes: Int64 = 0
+        for index in plan.sortedVisibleIndices where selectedIDs.contains(items[index].id) {
+            count += 1
+            bytes += items[index].sizeBytes
         }
-        return d
+        return (count, bytes)
     }
 
-    private var selectedInScopeCount: Int {
-        let selectedIDs = store.scanSelection.cacheIDs
-        return eligibleSelectIndices.filter { selectedIDs.contains(items[$0].id) }.count
-    }
-
-    private var selectedInScopeBytes: Int64 {
-        let selectedIDs = store.scanSelection.cacheIDs
-        return eligibleSelectIndices
-            .filter { selectedIDs.contains(items[$0].id) }
-            .reduce(Int64(0)) { sum, index in sum + items[index].sizeBytes }
-    }
-
-    private var displayableItemCount: Int {
-        items.filter { SafetyFilter.all.matches($0.safetyInfo) }.count
-    }
-
-    private var totalSize: Int64 {
-        items.filter { SafetyFilter.all.matches($0.safetyInfo) }.reduce(Int64(0)) { $0 + $1.sizeBytes }
-    }
-
-    private var visibleTotalSize: Int64 {
-        return visibleIndices.reduce(Int64(0)) { sum, index in sum + items[index].sizeBytes }
-    }
-
-    private var subtitleItemCount: Int {
-        currentSafetyFilter == .all ? displayableItemCount : visibleIndices.count
-    }
-
-    private var subtitleTotalSize: Int64 {
-        currentSafetyFilter == .all ? totalSize : visibleTotalSize
-    }
-
-    private var subtitleItemLabel: String {
-        subtitleItemCount == 1 ? "item" : "items"
-    }
-
-    private var pageSubtitle: String {
-        return "\(subtitleItemCount) \(subtitleItemLabel) · \(formatBytes(subtitleTotalSize)) recoverable"
-    }
-
-    private var showsListContent: Bool {
-        !items.isEmpty && !visibleIndices.isEmpty
+    private func pageSubtitle(plan: ListPlan) -> String {
+        let count = currentSafetyFilter == .all ? plan.displayableCount : plan.visibleCount
+        let bytes = currentSafetyFilter == .all ? plan.displayableTotalBytes : plan.visibleTotalBytes
+        return "\(count) \(count == 1 ? "item" : "items") · \(formatBytes(bytes)) recoverable"
     }
 
     var body: some View {
-        Group {
+        let plan = makeListPlan()
+        return Group {
             if usesExternalScrollContainer {
-                externalScrollBody
+                externalScrollBody(plan: plan)
             } else {
-                standardBody
+                standardBody(plan: plan)
             }
         }
         .background(AppColors.bgBase)
     }
 
-    private var standardBody: some View {
+    private func standardBody(plan: ListPlan) -> some View {
         VStack(spacing: 0) {
             if showsPageHeader {
-                AppSectionPageHeader(title: "App Caches", subtitle: pageSubtitle) {
+                AppSectionPageHeader(title: "App Caches", subtitle: pageSubtitle(plan: plan)) {
                     AppScanCleanActions(onScan: onScan, scanPhase: scanPhase)
                 }
             }
 
-            scanControlsChrome
-            scanListStack
+            scanControlsChrome(plan: plan)
+            scanListStack(plan: plan)
         }
     }
 
     @ViewBuilder
-    private var externalScrollBody: some View {
+    private func externalScrollBody(plan: ListPlan) -> some View {
         if #available(macOS 26.0, *) {
             VStack(spacing: 0) {
-                fixedScanTabHeader
+                filterToolbarChrome(plan: plan)
 
-                if showsListContent {
+                if !items.isEmpty && !plan.isEmpty {
                     ZStack {
-                        cacheResultsList
-                            .scanTabSoftScrollEdge { selectAllRowChrome }
+                        cacheResultsList(plan: plan)
+                            .scanTabSoftScrollEdge { selectAllRowChrome(plan: plan) }
 
                         if store.isDeleting && !store.isInteractiveSafeCleanupInProgress && store.manualDeletionSession == nil {
                             CleaningOverlay()
@@ -182,32 +194,29 @@ struct AppCachesView<PageHeader: View>: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
                     VStack(spacing: 0) {
-                        selectAllRowChrome
-                        scanListStack
+                        selectAllRowChrome(plan: plan)
+                        scanListStack(plan: plan)
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
                     }
                 }
             }
         } else {
-            standardBody
+            standardBody(plan: plan)
         }
     }
 
     /// Filter chips — fixed above the scroll edge; page title lives in the parent column header.
-    private var fixedScanTabHeader: some View {
-        filterToolbarChrome
-    }
-
-    private var filterToolbarChrome: some View {
+    private func filterToolbarChrome(plan: ListPlan) -> some View {
         // Scoped to scanSelection so the selected count/clean button update on a
         // toggle without re-rendering GeneralModeView (which reverts list scroll).
         ScanSelectionScope(selection: store.scanSelection, isSelected: { _ in false }) { _ in
+            let scope = selectedInScope(plan: plan)
             FilterSortToolbar(
                 safetyFilter: safetyFilterBinding,
                 sortOption: sortOptionBinding,
-                chipCounts: chipCounts,
-                selectedInScopeCount: selectedInScopeCount,
-                selectedInScopeBytes: selectedInScopeBytes,
+                chipCounts: plan.chipCounts,
+                selectedInScopeCount: scope.count,
+                selectedInScopeBytes: scope.bytes,
                 isDeleting: store.isDeleting,
                 onCleanSelected: {
                     Task {
@@ -222,16 +231,16 @@ struct AppCachesView<PageHeader: View>: View {
     }
 
     /// Bottom edge of the blur zone — list rows fade under this row only.
-    private var selectAllRowChrome: some View {
+    private func selectAllRowChrome(plan: ListPlan) -> some View {
         // Scoped so the tri-state updates on selection without re-rendering the
         // container (which would revert list scroll).
         ScanSelectionScope(selection: store.scanSelection, isSelected: { _ in false }) { _ in
             HStack(alignment: .bottom) {
-                TriStateCheckbox(title: "Select All", state: selectAllState) {
-                    toggleSelectAll()
+                TriStateCheckbox(title: "Select All", state: selectAllState(plan: plan)) {
+                    toggleSelectAll(plan: plan)
                 }
                 .fixedSize()
-                .disabled(eligibleSelectIndices.isEmpty)
+                .disabled(plan.isEmpty)
                 Spacer()
                 AppSortMenu(selection: sortOptionBinding)
             }
@@ -239,18 +248,19 @@ struct AppCachesView<PageHeader: View>: View {
         }
     }
 
-    private var scanControlsChrome: some View {
+    private func scanControlsChrome(plan: ListPlan) -> some View {
         VStack(spacing: 0) {
-            filterToolbarChrome
-            selectAllRowChrome
+            filterToolbarChrome(plan: plan)
+            selectAllRowChrome(plan: plan)
         }
     }
 
-    private var scanListStack: some View {
+    private func scanListStack(plan: ListPlan) -> some View {
         ZStack {
-            scanListOrPlaceholder
+            scanListOrPlaceholder(plan: plan)
 
-            if store.isDeleting && showsListContent && !store.isInteractiveSafeCleanupInProgress
+            if store.isDeleting && !items.isEmpty && !plan.isEmpty
+                && !store.isInteractiveSafeCleanupInProgress
                 && store.manualDeletionSession == nil {
                 CleaningOverlay()
             }
@@ -259,21 +269,21 @@ struct AppCachesView<PageHeader: View>: View {
     }
 
     @ViewBuilder
-    private var scanListOrPlaceholder: some View {
+    private func scanListOrPlaceholder(plan: ListPlan) -> some View {
         if items.isEmpty {
             if isLoading {
                 scanningPlaceholder
             } else {
                 emptyState
             }
-        } else if visibleIndices.isEmpty {
+        } else if plan.isEmpty {
             if isLoading {
                 scanningPlaceholder
             } else {
                 emptyFilterState
             }
         } else {
-            cacheResultsList
+            cacheResultsList(plan: plan)
         }
     }
 
@@ -286,9 +296,9 @@ struct AppCachesView<PageHeader: View>: View {
     /// first appearance can reset scroll position to the first row.
     private static var topAnchorID: String { "app-caches-top" }
 
-    private var cacheResultsList: some View {
+    private func cacheResultsList(plan: ListPlan) -> some View {
         ScrollViewReader { proxy in
-            cacheResultsListContent
+            cacheResultsListContent(plan: plan)
                 .onChange(of: scanPhase) { newPhase in
                     // A new scan just finished populating the list.
                     guard newPhase == .completed else { return }
@@ -299,7 +309,7 @@ struct AppCachesView<PageHeader: View>: View {
         }
     }
 
-    private var cacheResultsListContent: some View {
+    private func cacheResultsListContent(plan: ListPlan) -> some View {
         List {
             Color.clear
                 .frame(height: 0)
@@ -308,7 +318,7 @@ struct AppCachesView<PageHeader: View>: View {
                 .listRowSeparator(.hidden)
                 .id(Self.topAnchorID)
 
-            ForEach(sortedVisibleIndices(), id: \.self) { index in
+            ForEach(plan.sortedVisibleIndices, id: \.self) { index in
                 let item = items[index]
                 let itemID = item.id
                 // Scope observes scanSelection so a toggle re-renders only the row,
@@ -334,8 +344,10 @@ struct AppCachesView<PageHeader: View>: View {
                         showUncommittedRepoChanges: item.gitStatus == .dirty,
                         onResetToAutomatic: { store.resetCacheItemToAutomatic(id: itemID) },
                         onExcludeFromScans: { store.excludeFromScans(item) },
-                        isUserOverride: item.locations.contains {
-                            store.userOverridePaths.contains($0.path.standardizedFileURL.path)
+                        // `standardizedPaths` is precomputed on the item; deriving it here
+                        // meant a filesystem stat per location, per row, per render.
+                        isUserOverride: item.standardizedPaths.contains {
+                            store.userOverridePaths.contains($0)
                         },
                         isMetadataPending: store.cacheItemHasPendingSize(item)
                     )
@@ -352,7 +364,9 @@ struct AppCachesView<PageHeader: View>: View {
         .scrollContentBackground(.hidden)
         .background(AppColors.bgBase)
         .animation(reduceMotion ? nil : .easeInOut(duration: 0.22), value: store.interactiveSafeCleanupRemovedPaths)
-        .animation(rowInsertionAnimation, value: items.map(\.id))
+        // O(1) stand-in for "the row set changed". `items.map(\.id)` allocated and then
+        // compared an array of every row's id string on every body evaluation.
+        .animation(rowInsertionAnimation, value: store.cacheItemsRevision)
     }
 
     private var rowInsertionAnimation: Animation? {
@@ -377,13 +391,6 @@ struct AppCachesView<PageHeader: View>: View {
             )
     }
 
-    private func isVisuallyRemovedBySafeCleanup(_ item: CacheItem) -> Bool {
-        let rowPaths = Set(item.locations.map { $0.path.standardizedFileURL.path })
-        let targetedPaths = rowPaths.intersection(store.interactiveSafeCleanupTargetPaths)
-        guard !targetedPaths.isEmpty else { return false }
-        return targetedPaths.isSubset(of: store.interactiveSafeCleanupRemovedPaths)
-    }
-
     private var emptyFilterState: some View {
         VStack(spacing: 4) {
             Text("Nothing here.")
@@ -394,8 +401,8 @@ struct AppCachesView<PageHeader: View>: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private func toggleSelectAll() {
-        let ix = eligibleSelectIndices
+    private func toggleSelectAll(plan: ListPlan) {
+        let ix = plan.sortedVisibleIndices
         guard !ix.isEmpty else { return }
         let ids = ix.map { items[$0].id }
         let allOn = ids.allSatisfy { store.scanSelection.cacheIDs.contains($0) }

--- a/purge/Views/LargeFilesView.swift
+++ b/purge/Views/LargeFilesView.swift
@@ -392,7 +392,7 @@ struct LargeFilesView: View {
         .disablingListSelection()
         .scrollContentBackground(.hidden)
         .background(AppColors.bgBase)
-        .animation(reduceMotion ? nil : .easeInOut(duration: 0.22), value: store.largeFiles.map(\.id))
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.22), value: store.largeFilesRevision)
     }
 
     private var emptyState: some View {

--- a/purge/Views/Onboarding/OnboardingPermissionsStep.swift
+++ b/purge/Views/Onboarding/OnboardingPermissionsStep.swift
@@ -71,7 +71,9 @@ struct OnboardingPermissionsStep: View {
       didOpenFullDiskAccessSettings = true
     }
     openFullDiskAccessSettings()
-    refreshFullDiskAccess()
+    withAnimation(.easeInOut(duration: 0.2)) {
+      store.refreshPermission()
+    }
   }
 
   private func enableLoginItem() {
@@ -84,8 +86,13 @@ struct OnboardingPermissionsStep: View {
 
   private func pollFullDiskAccess() async {
     while !Task.isCancelled {
-      await MainActor.run {
-        refreshFullDiskAccess()
+      // Probes off the main actor and publishes only on a change, so the once-a-second
+      // poll cannot stutter the step's animations. See `probeFullDiskAccess`.
+      let granted = await store.probeFullDiskAccess()
+      if granted != store.hasFullDiskAccess {
+        withAnimation(.easeInOut(duration: 0.2)) {
+          store.applyFullDiskAccess(granted)
+        }
       }
 
       do {
@@ -93,12 +100,6 @@ struct OnboardingPermissionsStep: View {
       } catch {
         break
       }
-    }
-  }
-
-  private func refreshFullDiskAccess() {
-    withAnimation(.easeInOut(duration: 0.2)) {
-      store.refreshPermission()
     }
   }
 }

--- a/purge/Views/Onboarding/OnboardingPermissionsStep.swift
+++ b/purge/Views/Onboarding/OnboardingPermissionsStep.swift
@@ -70,10 +70,11 @@ struct OnboardingPermissionsStep: View {
     withAnimation(.easeInOut(duration: 0.2)) {
       didOpenFullDiskAccessSettings = true
     }
+    // No re-check here: this only opens System Settings, so access cannot have been
+    // granted yet, and the probe lists three Library directories on the main thread.
+    // `pollFullDiskAccess` is already running for this step and picks the grant up
+    // within a second, off the main actor.
     openFullDiskAccessSettings()
-    withAnimation(.easeInOut(duration: 0.2)) {
-      store.refreshPermission()
-    }
   }
 
   private func enableLoginItem() {

--- a/purge/purgeApp.swift
+++ b/purge/purgeApp.swift
@@ -119,7 +119,7 @@ struct PurgeApp: App {
         }
 
         MenuBarExtra {
-            MenuBarContentView(model: menuModel)
+            MenuBarContentView(model: menuModel, store: store)
                 .environmentObject(store)
                 .environmentObject(diskStore)
                 .environmentObject(trashStore)


### PR DESCRIPTION
## What does this change?

Fixes the "lags a bit / not smooth" reports — both tab switching and the onboarding page transitions.

Everything here was measured rather than guessed, using a temporary harness (synthetic scan data + a 60 Hz main-loop hitch monitor) in Release. The harness is not part of this PR; it was removed before commit.

**Results at 400 items:**

| | before | after |
|---|---|---|
| Tab switch p95 | 136 ms | **33 ms** |
| Tab switch frames >100 ms | 53 | **22** |
| Worst single stall | 1187 ms | **227 ms** |
| Large Files, first open | 1151 ms freeze | **84 ms** |
| Onboarding, dropped frames per transition | 8–12 | **0** |
| Onboarding p95 | 114–135 ms | **17.7 ms** |

### Four root causes

**1. All four scanners walked the filesystem on the main thread.**
The project builds with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so `CacheScanner`, `DevScanner`, `LargeFileScanner` and `AIModelScanner` were implicitly main-actor isolated — and the `Task.detached` inside each `scanStream` hopped straight back to the main actor. A `Thread.isMainThread` probe confirmed it for all four. They are now `nonisolated`.

This is the largest fix and it affects every scan, not just tab switches.

**2. `URL.standardizedFileURL` stats the filesystem**, and it sat behind `CacheItem.id`, `DevTool.id`, `isVisuallyRemovedBySafeCleanup` and `cacheItemHasPendingSize` — properties SwiftUI reads once per row *and* again for every count/total helper. One render issued thousands of syscalls, visible as `faccessat` / `__mac_syscall` samples inside body evaluation. Identity and standardized paths are now resolved once at construction, and the row-visibility check is centralised on `PurgeStore` behind a guard that skips the whole scan when no interactive cleanup is running (i.e. almost always).

**3. `AppCachesView` re-derived `visibleIndices` from scratch at ~8 call sites per render.** Replaced with a single `ListPlan` computed once per body pass.

**4. Onboarding kept the entire main app mounted behind the overlay** at `opacity(0)` — the App Caches list and every row, laid out and rendered while competing with the step transitions — and polled the Full Disk Access probe (three Library directory listings) on the main actor once a second.

Also folds in in-flight scan-smoothness work that was already in the tree: a fixed-cadence flush throttle replacing a reset-debounce that never fired, memoised `DeletionSafetyPolicy` verdicts, a `BrandIconService` row-icon cache, and O(1) revision counters replacing animation keys that allocated an id array per body evaluation.

### Concurrency warnings went down

Marking the scanners `nonisolated` cascades to the value types they construct, so the models and shared helpers are marked `nonisolated` too. Rather than leave that as new warnings, it's followed through — net effect is **fewer** than before:

- actor-isolation warnings: **28 → 12**
- of which are errors under the Swift 6 language mode: **3 → 0**

### Two approaches tried and rejected

Both are recorded in code comments with their numbers so they aren't re-proposed:

- **Keeping visited tabs mounted** in a `ZStack` and toggling opacity — a net regression (p95 33 ms → 50 ms), because a mounted tab still re-evaluates its body on every store publish.
- **`.drawingGroup()` on the onboarding blur** — moved the blur to the GPU but traded it for synchronous GPU surface waits (`RB::SurfacePool::wait_image_queue` → `usleep`) on the main thread, and was slightly worse.

### A note on the test I didn't ship

My first attempt at an "off-main" regression test **passed with the bug deliberately reintroduced** — Swift 5 language mode diagnoses but does not enforce isolation on synchronous code, so constructing a main-actor type from a detached task runs off-main either way. I deleted it rather than ship a test that cannot fail. `ScannerOffMainTests` keeps only assertions verified to be sensitive (concurrent off-main Launch Services access, and model identity stability), and its suite comment documents the probe method for the isolation property itself.

## Related issue

<!-- none -->

## Screenshots

No visual changes — this is behaviour only. Verified by hand on an M-series Mac: tab switching and the full onboarding flow are smooth.

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I built and ran the app locally
- [x] I ran the test suite (`xcodebuild ... test`) and it passes
- [x] This PR is focused on a single fix/feature

Test suite passes apart from the pre-existing `LargeFileScanPolicyTests/cacheSafetyStillBlocksPersonalMediaPaths` failure, which I confirmed is already red on a clean `HEAD` worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Scanning and filesystem analysis now run more efficiently in the background, improving responsiveness.
  - Reduced repeated calculations for lists, cleanup checks, file paths, and application icons.
  - Improved scan coordination and concurrent sizing for smoother progress and result refreshes.

- **User Experience**
  - Cleanup totals and list changes now animate more smoothly while respecting Reduce Motion settings.
  - The main app loads only after onboarding is ready.
  - Full Disk Access checks refresh more reliably after returning from System Settings.

- **Visuals**
  - Added caching to improve icon loading and reduce repeated lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->