### PR TITLE
fix: stop reporting system protection without checking it

### DIFF
--- a/PurgeTests/CleanFailureReasonTests.swift
+++ b/PurgeTests/CleanFailureReasonTests.swift
@@ -37,24 +37,98 @@ struct CleanFailureReasonTests {
         (NSPOSIXErrorDomain, Int(EPERM)),
         (NSCocoaErrorDomain, NSFileWriteNoPermissionError),
     ])
-    func upgradesPermissionErrorsWhenFullDiskAccessGranted(domain: String, code: Int) {
+    func permissionErrorOnAnOrdinaryFileIsUnknownWhenFullDiskAccessGranted(
+        domain: String,
+        code: Int
+    ) throws {
         let error = NSError(domain: domain, code: code)
+        let file = try Self.makeTemporaryFile()
+        defer { try? FileManager.default.removeItem(at: file) }
+
         #expect(CleanFailureReason.from(error: error) == .needsFullDiskAccess)
+        // An ordinary user file is not protected by macOS, so we must not say it is.
         #expect(
-            CleanFailureReason.resolved(from: error, fullDiskAccessGranted: true)
-                == .systemProtected
+            CleanFailureReason.resolved(from: error, path: file.path, fullDiskAccessGranted: true)
+                == .unknown
         )
         #expect(
-            CleanFailureReason.resolved(from: error, fullDiskAccessGranted: false)
+            CleanFailureReason.resolved(from: error, path: file.path, fullDiskAccessGranted: false)
                 == .needsFullDiskAccess
         )
+    }
+
+    @Test func immutableFileIsReportedAsSystemProtected() throws {
+        let file = try Self.makeTemporaryFile()
+        defer {
+            try? FileManager.default.setAttributes([.immutable: false], ofItemAtPath: file.path)
+            try? FileManager.default.removeItem(at: file)
+        }
+        try FileManager.default.setAttributes([.immutable: true], ofItemAtPath: file.path)
+
+        #expect(FileProtection.blocksRemoval(file))
+        let error = NSError(domain: NSPOSIXErrorDomain, code: Int(EPERM))
+        #expect(
+            CleanFailureReason.resolved(from: error, path: file.path, fullDiskAccessGranted: true)
+                == .systemProtected
+        )
+    }
+
+    /// Removal unlinks a file from its directory, so an immutable directory
+    /// refuses it even though the file itself reads as perfectly ordinary.
+    /// `trashItem` fails here with `NSFileWriteNoPermissionError`, which would
+    /// otherwise be reported as "try again" — a retry that can never succeed.
+    @Test func fileInsideAnImmutableDirectoryIsReportedAsSystemProtected() throws {
+        let fm = FileManager.default
+        let directory = fm.temporaryDirectory
+            .appendingPathComponent("purge-protected-dir-\(UUID().uuidString)")
+        try fm.createDirectory(at: directory, withIntermediateDirectories: true)
+        let file = directory.appendingPathComponent("payload.bin")
+        try Data("x".utf8).write(to: file)
+        defer {
+            try? fm.setAttributes([.immutable: false], ofItemAtPath: directory.path)
+            try? fm.removeItem(at: directory)
+        }
+        try fm.setAttributes([.immutable: true], ofItemAtPath: directory.path)
+
+        #expect(!FileProtection.isImmutable(file))
+        #expect(FileProtection.blocksRemoval(file))
+
+        let error = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteNoPermissionError)
+        #expect(
+            CleanFailureReason.resolved(from: error, path: file.path, fullDiskAccessGranted: true)
+                == .systemProtected
+        )
+    }
+
+    @Test func ordinaryFileIsNotTreatedAsProtected() throws {
+        let file = try Self.makeTemporaryFile()
+        defer { try? FileManager.default.removeItem(at: file) }
+        #expect(!FileProtection.blocksRemoval(file))
     }
 
     @Test func preservesNonPermissionReasonsWhenFullDiskAccessGranted() {
         let busy = NSError(domain: NSPOSIXErrorDomain, code: Int(EBUSY))
         #expect(
-            CleanFailureReason.resolved(from: busy, fullDiskAccessGranted: true) == .inUse
+            CleanFailureReason.resolved(from: busy, path: "/tmp/none", fullDiskAccessGranted: true)
+                == .inUse
         )
+    }
+
+    @Test func safetySkipsAreNotDescribedAsSystemProtection() {
+        let skipped = SkippedDeletionItem(
+            path: "/tmp/example",
+            displayName: "example",
+            reason: "This file was skipped for safety",
+            isUserVisible: true
+        )
+        #expect(CleanFailureItem(skipped: skipped).reason == .safetySkipped)
+    }
+
+    private static func makeTemporaryFile() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("purge-protection-\(UUID().uuidString)")
+        try Data("x".utf8).write(to: url)
+        return url
     }
 }
 

--- a/purge/Models/CleanFailure.swift
+++ b/purge/Models/CleanFailure.swift
@@ -1,9 +1,45 @@
 import Foundation
 
+/// Whether the filesystem itself will refuse to give a file up, no matter what
+/// permissions Purge holds. This is the only thing that justifies telling
+/// someone macOS protects a file — an ordinary permission error does not.
+nonisolated enum FileProtection {
+    static func isImmutable(_ url: URL) -> Bool {
+        let values = try? url.resourceValues(forKeys: [.isUserImmutableKey, .isSystemImmutableKey])
+        return values?.isUserImmutable == true || values?.isSystemImmutable == true
+    }
+
+    /// SIP marks its own files with a `com.apple.rootless` xattr.
+    static func isRootlessProtected(_ url: URL) -> Bool {
+        url.withUnsafeFileSystemRepresentation { pointer in
+            guard let pointer else { return false }
+            return getxattr(pointer, "com.apple.rootless", nil, 0, 0, XATTR_NOFOLLOW) >= 0
+        }
+    }
+
+    /// Removing a file means unlinking it from its directory, so an immutable
+    /// *parent* refuses the removal even when the file itself looks ordinary —
+    /// verified: `trashItem` then fails with `NSFileWriteNoPermissionError`
+    /// while the file still reports as mutable.
+    ///
+    /// The parent is checked for immutability only, deliberately. A directory
+    /// can carry `com.apple.rootless` and still hand its contents over freely —
+    /// the per-user temp directory is marked `com.apple.rootless: folders` and
+    /// files inside it trash without complaint. Testing the parent for rootless
+    /// would condemn every one of them.
+    static func blocksRemoval(_ url: URL) -> Bool {
+        if isImmutable(url) || isRootlessProtected(url) { return true }
+        let parent = url.deletingLastPathComponent()
+        guard parent.path != url.path else { return false }
+        return isImmutable(parent)
+    }
+}
+
 nonisolated enum CleanFailureReason: Equatable, Error {
     case needsFullDiskAccess
     case inUse
     case systemProtected
+    case safetySkipped
     case unknown
 
     var explanation: String {
@@ -14,8 +50,10 @@ nonisolated enum CleanFailureReason: Equatable, Error {
             "An app is still using this. Quit it and clean again."
         case .systemProtected:
             "macOS protects this one and won't let it be removed."
+        case .safetySkipped:
+            "Purge left this one alone to stay on the safe side."
         case .unknown:
-            "This one couldn't be removed."
+            "This one couldn't be removed. Try again."
         }
     }
 
@@ -27,6 +65,8 @@ nonisolated enum CleanFailureReason: Equatable, Error {
             "app.badge.fill"
         case .systemProtected:
             "lock.shield.fill"
+        case .safetySkipped:
+            "hand.raised.fill"
         case .unknown:
             "exclamationmark.circle.fill"
         }
@@ -82,14 +122,20 @@ nonisolated enum CleanFailureReason: Equatable, Error {
         return .unknown
     }
 
-    /// Maps a deletion error to a user-facing reason, upgrading permission errors to
-    /// `systemProtected` when Full Disk Access is already granted.
-    static func resolved(from error: Error, fullDiskAccessGranted: Bool) -> CleanFailureReason? {
+    /// Maps a deletion error to a user-facing reason. When Full Disk Access is
+    /// already granted a permission error clearly isn't about FDA — but that on
+    /// its own says nothing about macOS protecting the file, so we only claim
+    /// protection when the file — or the directory holding it — really is
+    /// immutable or SIP-marked. Anything else is honestly unknown, and offering
+    /// a retry beats inventing a cause.
+    static func resolved(
+        from error: Error,
+        path: String,
+        fullDiskAccessGranted: Bool
+    ) -> CleanFailureReason? {
         guard let reason = from(error: error) else { return nil }
-        if fullDiskAccessGranted, reason == .needsFullDiskAccess {
-            return .systemProtected
-        }
-        return reason
+        guard fullDiskAccessGranted, reason == .needsFullDiskAccess else { return reason }
+        return FileProtection.blocksRemoval(URL(fileURLWithPath: path)) ? .systemProtected : .unknown
     }
 
     private static func isFileNotFound(_ error: NSError) -> Bool {
@@ -140,7 +186,7 @@ struct CleanFailureItem: Identifiable, Equatable {
             id: skipped.id,
             path: skipped.path,
             displayName: skipped.displayName,
-            reason: .systemProtected,
+            reason: .safetySkipped,
             sizeBytes: 0
         )
     }

--- a/purge/Services/FileDeleter.swift
+++ b/purge/Services/FileDeleter.swift
@@ -365,6 +365,7 @@ nonisolated final class FileDeleter: Sendable {
     ) {
         guard let reason = CleanFailureReason.resolved(
             from: error,
+            path: path,
             fullDiskAccessGranted: PermissionChecker().hasFullDiskAccess()
         ) else {
             NSLog("Purge: item already gone, skipping %@", path)

--- a/purge/Services/LargeFileScanner.swift
+++ b/purge/Services/LargeFileScanner.swift
@@ -20,7 +20,8 @@ final class LargeFileScanner {
         let now = Date()
         let resourceKeys: Set<URLResourceKey> = [
             .isRegularFileKey, .isDirectoryKey, .totalFileAllocatedSizeKey, .fileSizeKey,
-            .contentAccessDateKey, .contentModificationDateKey, .isPackageKey
+            .contentAccessDateKey, .contentModificationDateKey, .isPackageKey,
+            .isUserImmutableKey, .isSystemImmutableKey
         ]
 
         for root in LargeFileScanPolicy.scanRoots(home: home) {
@@ -58,6 +59,13 @@ final class LargeFileScanner {
                     let days = Calendar.current.dateComponents([.day], from: lastUsed, to: now).day ?? 0
                     guard days >= staleDays else { continue }
                 }
+
+                // Never list a file the filesystem will refuse to give up — its own
+                // flags or its directory's. Offering it can only end in "couldn't be
+                // cleaned", so it does not belong in the list at all. The check runs
+                // last because it costs syscalls and only a handful of files, already
+                // past the size and staleness filters, get this far.
+                if FileProtection.blocksRemoval(fileURL) { continue }
 
                 continuation.yield(
                     LargeFile(


### PR DESCRIPTION
## What does this change?

A clean run reported **"1 item couldn't be cleaned — macOS protects this one and won't let it be removed"** for `hermes-ios-0.79.6-release.tar.gz`.

That file is user-owned, writable, has no ACL, and carries `flags=64` (`UF_TRACKED`, not immutable). Trashing a file in the same directory via `FileManager.trashItem` succeeds. macOS does not protect it — the message was invented, in two places:

- `resolved(from:fullDiskAccessGranted:)` upgraded **any** permission error to `.systemProtected` once Full Disk Access was on. "Not an FDA problem" is not the same as "macOS protects this."
- `CleanFailureItem(skipped:)` hardcoded `.systemProtected` for every safety skip, discarding the skip's own reason.

Now failures probe the file. An immutable flag or SIP's `com.apple.rootless` xattr justifies the protection message; nothing else does. Anything unexplained says so and offers a retry. Safety skips get their own `.safetySkipped` reason.

The probe also covers the **parent directory**, because removing a file unlinks it from its directory. Verified: with the parent locked, the file still reports `isUserImmutable == false`, yet `trashItem` fails with `NSFileWriteNoPermissionError` — which would otherwise be reported as "try again", a retry that can never succeed.

The parent is checked for immutability only, deliberately. A directory can carry `com.apple.rootless` and still hand its contents over freely: the per-user temp directory is marked `com.apple.rootless: folders` and files inside it trash without complaint. Testing the parent for rootless too would condemn every one of them — reintroducing the exact false claim this PR removes.

`LargeFileScanner` also drops genuinely immutable and SIP-marked files during the walk, so a file that can never be trashed is never offered in the first place.

The "couldn't be cleaned" panel stays. It can't be made unnecessary — a file can be locked, opened by an app, or have its permissions changed between the scan and the clean — but it should be truthful and rare.

## Related issue

None.

## Screenshots

No layout changes; the wording changes:

- Unexplained error: ~~"macOS protects this one and won't let it be removed."~~ → "This one couldn't be removed. Try again." (now with a retry action)
- Safety skip: ~~"macOS protects this one…"~~ → "Purge left this one alone to stay on the safe side."

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I built and ran the app locally
- [x] I ran the test suite (`xcodebuild ... test`) and it passes — see caveat
- [x] This PR is focused on a single fix/feature

New cases in `CleanFailureReasonTests` covering an ordinary file, a `chflags`-immutable file, a file inside an immutable directory, and a safety skip.

Caveat: `LargeFileScanPolicyTests/cacheSafetyStillBlocksPersonalMediaPaths` fails, identically on clean `main`, and is unrelated to this change.
