### PR TITLE
fix: keep the four scanners off the main thread

### DIFF
--- a/PurgeTests/ScannerOffMainTests.swift
+++ b/PurgeTests/ScannerOffMainTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import Purge
+
+/// The Large Files walk must not run on the main thread. `Task.detached` is not
+/// enough on its own: with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, an
+/// unannotated scanner type makes its own `static func run` MainActor-isolated,
+/// so `await Self.run(…)` hops straight back to main and the whole
+/// home-directory sweep — every `resourceValues`, `getxattr` and directory read
+/// — lands on the UI thread. Nothing fails to compile when that happens, which
+/// is why this is a runtime probe.
+///
+/// Verified to fail: removing `nonisolated` from `LargeFileScanner` makes this
+/// test report `true`.
+@Suite("Scanners stay off the main thread")
+struct ScannerOffMainTests {
+    @MainActor
+    @Test func largeFileWalkDoesNotRunOnTheMainThread() async {
+        LargeFileScanner.ranOnMainThread = nil
+
+        // A huge floor means nothing is yielded, so the test does not depend on
+        // what happens to be on disk. The walk still starts, and the probe is
+        // set on the first directory entry it touches.
+        let stream = LargeFileScanner().scanStream(minBytes: .max, staleDays: 0)
+        let consumer = Task { @MainActor in
+            for await _ in stream {}
+        }
+        for _ in 0..<200 where LargeFileScanner.ranOnMainThread == nil {
+            try? await Task.sleep(nanoseconds: 25_000_000)
+        }
+        consumer.cancel()
+
+        #expect(LargeFileScanner.ranOnMainThread != nil, "probe never fired — the walk did not start")
+        #expect(
+            LargeFileScanner.ranOnMainThread == false,
+            "the filesystem walk ran on the main thread — check `nonisolated` on LargeFileScanner"
+        )
+    }
+}

--- a/purge/Services/AIModelScanner.swift
+++ b/purge/Services/AIModelScanner.swift
@@ -8,7 +8,7 @@ import Foundation
 /// a model without Ollama noticing — the manifest would still claim the model
 /// is installed. Blobs are also shared between models, so the reclaimable size
 /// of a model is only the blobs no other manifest references.
-final class AIModelScanner {
+nonisolated final class AIModelScanner {
     func scanStream(minBytes: Int64, staleDays: Int) -> AsyncStream<LargeFile> {
         AsyncStream { continuation in
             let task = Task.detached(priority: .userInitiated) {

--- a/purge/Services/CacheScanner.swift
+++ b/purge/Services/CacheScanner.swift
@@ -7,7 +7,7 @@ enum CacheScanEvent {
     case sizeResolved(path: String, sizeBytes: Int64, lastModified: Date)
 }
 
-final class CacheScanner {
+nonisolated final class CacheScanner {
     private struct SizeJob {
         let path: URL
     }

--- a/purge/Services/DevScanner.swift
+++ b/purge/Services/DevScanner.swift
@@ -9,7 +9,7 @@ enum DeveloperScanEvent {
     case simulatorSizeResolved(id: UUID, sizeBytes: Int64)
 }
 
-final class DevScanner {
+nonisolated final class DevScanner {
     private struct DevToolSizeJob {
         let toolID: String
         let toolLabel: String

--- a/purge/Services/LargeFileScanner.swift
+++ b/purge/Services/LargeFileScanner.swift
@@ -1,6 +1,15 @@
 import Foundation
 
-final class LargeFileScanner {
+nonisolated final class LargeFileScanner {
+    /// Records which thread the walk actually ran on, for the regression test.
+    ///
+    /// This needs a runtime probe rather than a compile-time guarantee: the
+    /// project builds in Swift 5 language mode, where isolation is not
+    /// enforced, so dropping `nonisolated` from this class silently moves the
+    /// whole filesystem walk back onto the main thread and nothing fails to
+    /// compile. Written once per scan, read only by tests.
+    nonisolated(unsafe) static var ranOnMainThread: Bool?
+
     func scanStream(minBytes: Int64, staleDays: Int) -> AsyncStream<LargeFile> {
         AsyncStream { continuation in
             let task = Task.detached(priority: .userInitiated) {
@@ -34,6 +43,7 @@ final class LargeFileScanner {
             ) else { continue }
 
             while let next = enumerator.nextObject() {
+                if ranOnMainThread == nil { ranOnMainThread = pthread_main_np() != 0 }
                 if Task.isCancelled { break }
                 guard let fileURL = next as? URL else { continue }
 


### PR DESCRIPTION
## What does this change?

The Large Files scan — and the cache, dev and AI-model scans — were running their entire filesystem walk **on the main thread**, despite each one starting from `Task.detached`.

With `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, an unannotated scanner type makes its own `static func run` MainActor-isolated, so `await Self.run(…)` hops straight back to main. Every `resourceValues`, `getxattr` and directory read of a full home-directory sweep was landing on the UI thread.

Measured in the real app target rather than inferred — recording `pthread_main_np()` on the first directory entry the walk touches:

```
before:  walk on main thread = Optional(true)
after:   walk on main thread = Optional(false)
```

`FileDeleter` got `nonisolated` in 96af8b8, but no commit ever added it to `LargeFileScanner`, `CacheScanner`, `DevScanner` or `AIModelScanner` — `git log -S` finds none. So this half was never applied rather than regressed. All four now match `FileDeleter`.

`ScannerOffMainTests` guards it. This has to be a **runtime** probe: the project builds in Swift 5 language mode, where isolation is not enforced, so dropping `nonisolated` silently moves the walk back to main and nothing fails to compile. I confirmed the test genuinely fails in that state rather than assuming it would.

The one cost is a small test hook in production code (`LargeFileScanner.ranOnMainThread`). Happy to drop the test if that isn't worth it, but this bug is otherwise invisible.

## Related issue

None.

## Screenshots

Not applicable — no visual change. The difference is UI responsiveness during a scan.

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I built and ran the app locally
- [x] I ran the test suite (`xcodebuild ... test`) and it passes — see caveat
- [x] This PR is focused on a single fix/feature

Caveat: `LargeFileScanPolicyTests/cacheSafetyStillBlocksPersonalMediaPaths` fails, identically on clean `main`, and is unrelated to this change.
