### PR TITLE
feat: show scan items in Finder from the row context menu

### DIFF
--- a/PurgeTests/FinderRevealTests.swift
+++ b/PurgeTests/FinderRevealTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import Purge
+
+/// A multi-location row reveals folders through a "Show in Finder" submenu, and each
+/// entry's label is the only place the user sees *which* folder holds the bulk. These
+/// pin that label: abbreviated path, plus a size only when one is actually known.
+@Suite("Finder reveal menu labels")
+@MainActor
+struct FinderRevealTests {
+    private var home: URL {
+        FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL
+    }
+
+    @Test func homeRelativePathIsAbbreviated() {
+        let url = home.appendingPathComponent("Library/Caches/com.example.app")
+        let title = FinderReveal.menuTitle(for: ScanRowLocation(url: url, sizeBytes: nil))
+
+        #expect(title == "~/Library/Caches/com.example.app")
+    }
+
+    @Test func pathOutsideHomeStaysAbsolute() {
+        let title = FinderReveal.menuTitle(
+            for: ScanRowLocation(url: URL(fileURLWithPath: "/Library/Caches/com.example.app"))
+        )
+
+        #expect(title == "/Library/Caches/com.example.app")
+    }
+
+    @Test func knownSizeIsAppended() {
+        let url = home.appendingPathComponent("go/pkg/mod")
+        let title = FinderReveal.menuTitle(for: ScanRowLocation(url: url, sizeBytes: 4_200_000_000))
+
+        #expect(title == "~/go/pkg/mod — \(formatBytes(4_200_000_000))")
+    }
+
+    /// Sizes arrive asynchronously after a scan, so a location can legitimately have no
+    /// size yet. A bare "— Zero KB" would read as an empty folder rather than a pending one.
+    @Test func unknownSizeIsOmittedRatherThanShownAsZero() {
+        let url = home.appendingPathComponent("go/pkg/mod")
+
+        #expect(
+            FinderReveal.menuTitle(for: ScanRowLocation(url: url, sizeBytes: nil)) == "~/go/pkg/mod"
+        )
+        #expect(
+            FinderReveal.menuTitle(for: ScanRowLocation(url: url, sizeBytes: 0)) == "~/go/pkg/mod"
+        )
+    }
+
+    /// The submenu labels a location by its path; a trailing slash would make two
+    /// spellings of the same folder look like two different rows.
+    @Test func trailingSlashIsNormalized() {
+        let url = home.appendingPathComponent("Library/Caches/com.example.app/")
+        let title = FinderReveal.menuTitle(for: ScanRowLocation(url: url, sizeBytes: nil))
+
+        #expect(title == "~/Library/Caches/com.example.app")
+    }
+}

--- a/PurgeTests/FinderRevealTests.swift
+++ b/PurgeTests/FinderRevealTests.swift
@@ -47,6 +47,23 @@ struct FinderRevealTests {
         )
     }
 
+    /// `hasPrefix` is a string test, not a path test: a sibling home whose name merely
+    /// starts with the current user's would otherwise abbreviate to `~2/cache` — a label
+    /// pointing at a folder that does not exist, on a menu item that deletes things.
+    @Test func siblingHomeWithAPrefixNameIsNotAbbreviated() {
+        let sibling = URL(fileURLWithPath: home.path + "2/cache")
+        let title = FinderReveal.menuTitle(for: ScanRowLocation(url: sibling, sizeBytes: nil))
+
+        #expect(title == sibling.standardizedFileURL.path)
+        #expect(!title.hasPrefix("~"))
+    }
+
+    /// The guard above must not cost the ordinary case: the home directory itself still
+    /// abbreviates, since there is no remainder to check for a separator.
+    @Test func homeDirectoryItselfAbbreviatesToTilde() {
+        #expect(FinderReveal.menuTitle(for: ScanRowLocation(url: home)) == "~")
+    }
+
     /// The submenu labels a location by its path; a trailing slash would make two
     /// spellings of the same folder look like two different rows.
     @Test func trailingSlashIsNormalized() {

--- a/purge/Utilities/FilePathDisplay.swift
+++ b/purge/Utilities/FilePathDisplay.swift
@@ -8,6 +8,11 @@ nonisolated func displayDirectoryPath(for directoryURL: URL) -> String {
     guard path.hasPrefix(home) else { return path }
     let remainder = String(path.dropFirst(home.count))
     if remainder.isEmpty { return "~" }
+    // A string prefix is not a path prefix: with home `/Users/alice`, the sibling
+    // home `/Users/alice2/cache` also passes `hasPrefix` and would abbreviate to
+    // `~2/cache`, naming a folder that does not exist. Only substitute when the
+    // match ends on a path boundary.
+    guard remainder.hasPrefix("/") else { return path }
     return "~" + remainder
 }
 

--- a/purge/Utilities/FinderReveal.swift
+++ b/purge/Utilities/FinderReveal.swift
@@ -1,0 +1,45 @@
+import AppKit
+import Foundation
+
+/// One filesystem location a scan row can reveal. `sizeBytes` is shown in the
+/// "Show in Finder" submenu so a multi-location row says which folder holds the bulk.
+nonisolated struct ScanRowLocation: Hashable {
+    let url: URL
+    let sizeBytes: Int64?
+
+    init(url: URL, sizeBytes: Int64? = nil) {
+        self.url = url
+        self.sizeBytes = sizeBytes
+    }
+}
+
+@MainActor
+enum FinderReveal {
+    /// Reveals exactly one folder.
+    ///
+    /// Deliberately never called with several URLs at once: `activateFileViewerSelecting`
+    /// groups its argument by parent directory and opens one Finder window *per distinct
+    /// parent*. Cache locations for a single app almost always sit under different parents
+    /// (`~/Library/Caches`, `~/Library/Application Support`, `~/Library/Containers`), so
+    /// passing them together fans out a burst of windows. Multi-location rows offer a
+    /// submenu instead and reveal the one the user picked.
+    static func show(_ url: URL) {
+        NSWorkspace.shared.activateFileViewerSelecting([url.standardizedFileURL])
+    }
+
+    static func copyPaths(_ urls: [URL]) {
+        guard !urls.isEmpty else { return }
+        let text = urls
+            .map { $0.standardizedFileURL.path }
+            .joined(separator: "\n")
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+
+    /// Submenu label: abbreviated path, plus size when known.
+    static func menuTitle(for location: ScanRowLocation) -> String {
+        let path = displayDirectoryPath(for: location.url)
+        guard let sizeBytes = location.sizeBytes, sizeBytes > 0 else { return path }
+        return "\(path) — \(formatBytes(sizeBytes))"
+    }
+}

--- a/purge/Views/DevModeView.swift
+++ b/purge/Views/DevModeView.swift
@@ -706,6 +706,17 @@ struct DevToolsView<PageHeader: View>: View {
                             showUncommittedRepoChanges: !isDevToolMetadataPending(tool) && toolShowsUncommitted(tool),
                             onResetToAutomatic: primaryPath != nil ? { store.resetDevToolToAutomatic(id: toolID) } : nil,
                             onExcludeFromScans: { store.excludeFromScans(tool) },
+                            revealLocations: {
+                                // `standardizedPaths` is precomputed and parallel to `paths`,
+                                // and is the key `pathSizeBytesByPath` uses.
+                                zip(tool.paths, tool.standardizedPaths).map { path, key in
+                                    ScanRowLocation(
+                                        url: path,
+                                        sizeBytes: tool.pathSizeBytesByPath[key]
+                                            ?? (tool.paths.count == 1 ? tool.sizeBytes : nil)
+                                    )
+                                }
+                            },
                             isUserOverride: primaryPath.map { store.userOverridePaths.contains($0.standardizedFileURL.path) } ?? false,
                             isMetadataPending: isDevToolMetadataPending(tool)
                         )
@@ -750,6 +761,9 @@ struct DevToolsView<PageHeader: View>: View {
                                     showUncommittedRepoChanges: false,
                                     onResetToAutomatic: nil,
                                     onExcludeFromScans: { store.excludeFromScans(device) },
+                                    revealLocations: {
+                                        [ScanRowLocation(url: device.folderURL, sizeBytes: device.sizeOnDisk)]
+                                    },
                                     isUserOverride: false,
                                     allowsBulkSelection: true,
                                     isMetadataPending: isSimulatorMetadataPending(device),
@@ -922,11 +936,20 @@ struct DevToolsView<PageHeader: View>: View {
             // Header only: an overlay across the whole card would swallow the
             // right-click meant for an individual artifact row.
             .overlay {
-                ScanRowContextMenu(
-                    isMenuActive: .constant(false),
-                    title: "Exclude project from scans",
-                    action: { store.excludeProjectGroupFromScans(groupID: group.id) }
-                )
+                ScanRowContextMenu(isMenuActive: .constant(false)) {
+                    [
+                        .action(title: "Exclude project from scans") {
+                            store.excludeProjectGroupFromScans(groupID: group.id)
+                        },
+                        .separator,
+                        .action(title: "Show in Finder") {
+                            FinderReveal.show(group.rootPath)
+                        },
+                        .action(title: "Copy Path") {
+                            FinderReveal.copyPaths([group.rootPath])
+                        }
+                    ]
+                }
             }
 
             if isExpanded {
@@ -993,6 +1016,9 @@ struct DevToolsView<PageHeader: View>: View {
                     onResetToAutomatic: { store.resetProjectArtifactToAutomatic(groupID: groupID, artifactID: artifactID) },
                     onExcludeFromScans: {
                         store.excludeProjectArtifactFromScans(groupID: groupID, artifactID: artifactID)
+                    },
+                    revealLocations: {
+                        [ScanRowLocation(url: art.path, sizeBytes: art.sizeBytes)]
                     },
                     isUserOverride: store.userOverridePaths.contains(artifactPath),
                     showsBulkCheckbox: false,

--- a/purge/Views/DevModeView.swift
+++ b/purge/Views/DevModeView.swift
@@ -951,6 +951,17 @@ struct DevToolsView<PageHeader: View>: View {
                     ]
                 }
             }
+            // The overlay only answers a secondary click, which VoiceOver and the
+            // keyboard cannot produce.
+            .accessibilityAction(named: Text("Exclude project from scans")) {
+                store.excludeProjectGroupFromScans(groupID: group.id)
+            }
+            .accessibilityAction(named: Text("Show in Finder")) {
+                FinderReveal.show(group.rootPath)
+            }
+            .accessibilityAction(named: Text("Copy Path")) {
+                FinderReveal.copyPaths([group.rootPath])
+            }
 
             if isExpanded {
                 projectArtifactRows(groupIndex: currentGroupIndex)

--- a/purge/Views/GeneralModeView.swift
+++ b/purge/Views/GeneralModeView.swift
@@ -344,6 +344,11 @@ struct AppCachesView<PageHeader: View>: View {
                         showUncommittedRepoChanges: item.gitStatus == .dirty,
                         onResetToAutomatic: { store.resetCacheItemToAutomatic(id: itemID) },
                         onExcludeFromScans: { store.excludeFromScans(item) },
+                        revealLocations: {
+                            item.locations.map {
+                                ScanRowLocation(url: $0.path, sizeBytes: $0.sizeBytes)
+                            }
+                        },
                         // `standardizedPaths` is precomputed on the item; deriving it here
                         // meant a filesystem stat per location, per row, per render.
                         isUserOverride: item.standardizedPaths.contains {

--- a/purge/Views/ScanResultRow.swift
+++ b/purge/Views/ScanResultRow.swift
@@ -460,10 +460,12 @@ struct ScanResultRow: View {
 /// Exposes the right-click actions to VoiceOver and the keyboard, which cannot produce
 /// a secondary click.
 ///
-/// "Show in Finder" is a single action with a fixed name even when the row has several
-/// locations: `accessibilityAction(named:)` needs its label during `body`, so naming one
-/// action per location would force the path/size formatting we deliberately defer to
-/// right-click. It reveals the largest location — the one the visual submenu lists first.
+/// The Finder actions keep fixed names even when the row has several locations:
+/// `accessibilityAction(named:)` needs its label during `body`, so naming one action per
+/// location — or pluralizing "Copy Path" by counting them — would force the evaluation
+/// and formatting we deliberately defer to right-click. "Show in Finder" therefore
+/// reveals the largest location (the one the visual submenu lists first), and "Copy Path"
+/// copies every location, matching what the menu's "Copy Paths" does.
 private struct ScanRowAccessibilityActions: ViewModifier {
     let onExcludeFromScans: (() -> Void)?
     let revealLocations: (() -> [ScanRowLocation])?
@@ -472,6 +474,7 @@ private struct ScanRowAccessibilityActions: ViewModifier {
         content
             .modifier(OptionalAction(name: "Exclude from scans", handler: onExcludeFromScans))
             .modifier(OptionalAction(name: "Show in Finder", handler: revealHandler))
+            .modifier(OptionalAction(name: "Copy Path", handler: copyPathsHandler))
     }
 
     private var revealHandler: (() -> Void)? {
@@ -480,6 +483,13 @@ private struct ScanRowAccessibilityActions: ViewModifier {
             let largest = revealLocations().max { ($0.sizeBytes ?? 0) < ($1.sizeBytes ?? 0) }
             guard let largest else { return }
             FinderReveal.show(largest.url)
+        }
+    }
+
+    private var copyPathsHandler: (() -> Void)? {
+        guard let revealLocations else { return nil }
+        return {
+            FinderReveal.copyPaths(revealLocations().map(\.url))
         }
     }
 

--- a/purge/Views/ScanResultRow.swift
+++ b/purge/Views/ScanResultRow.swift
@@ -45,6 +45,10 @@ struct ScanResultRow: View {
     let onResetToAutomatic: (() -> Void)?
     /// When nil, the row omits the "Exclude from scans" context-menu action.
     var onExcludeFromScans: (() -> Void)?
+    /// Folders this row would delete, for the "Show in Finder" context-menu action.
+    /// A closure, not an array: it is only evaluated on right-click, so no row pays
+    /// for path standardization or size formatting during `body`.
+    var revealLocations: (() -> [ScanRowLocation])?
     let isUserOverride: Bool
     /// When `false`, the row checkbox is disabled (e.g. high-risk items that should not participate in bulk select).
     var allowsBulkSelection: Bool = true
@@ -121,6 +125,7 @@ struct ScanResultRow: View {
         showUncommittedRepoChanges: Bool = false,
         onResetToAutomatic: (() -> Void)? = nil,
         onExcludeFromScans: (() -> Void)? = nil,
+        revealLocations: (() -> [ScanRowLocation])? = nil,
         isUserOverride: Bool = false,
         allowsBulkSelection: Bool = true,
         showsBulkCheckbox: Bool = true,
@@ -140,6 +145,7 @@ struct ScanResultRow: View {
         self.showUncommittedRepoChanges = showUncommittedRepoChanges
         self.onResetToAutomatic = onResetToAutomatic
         self.onExcludeFromScans = onExcludeFromScans
+        self.revealLocations = revealLocations
         self.isUserOverride = isUserOverride
         self.allowsBulkSelection = allowsBulkSelection
         self.showsBulkCheckbox = showsBulkCheckbox
@@ -161,7 +167,7 @@ struct ScanResultRow: View {
             )
             .animation(.easeOut(duration: 0.12), value: isContextMenuActive)
 
-        if let onExcludeFromScans {
+        if onExcludeFromScans != nil || revealLocations != nil {
             // Not SwiftUI's `.contextMenu`: that hands the menu to the enclosing
             // NSTableView, which then paints its own blue contextual-menu highlight
             // around the whole list row. Consuming the right-click ourselves keeps
@@ -169,16 +175,63 @@ struct ScanResultRow: View {
             row.overlay {
                 ScanRowContextMenu(
                     isMenuActive: $isContextMenuActive,
-                    title: "Exclude from scans",
-                    action: onExcludeFromScans
+                    entries: contextMenuEntries
                 )
             }
             // The overlay only answers a secondary click, which VoiceOver and the
-            // keyboard cannot produce; this exposes the same action to them.
-            .accessibilityAction(named: Text("Exclude from scans"), onExcludeFromScans)
+            // keyboard cannot produce; this exposes the same actions to them.
+            .modifier(
+                ScanRowAccessibilityActions(
+                    onExcludeFromScans: onExcludeFromScans,
+                    revealLocations: revealLocations
+                )
+            )
         } else {
             row
         }
+    }
+
+    /// Built on right-click, not during `body` — see `ScanRowContextMenu.entries`.
+    private func contextMenuEntries() -> [ScanRowMenuEntry] {
+        var entries: [ScanRowMenuEntry] = []
+
+        if let onExcludeFromScans {
+            entries.append(.action(title: "Exclude from scans", handler: onExcludeFromScans))
+        }
+
+        // Largest first, so the submenu leads with the folder holding the bulk.
+        let locations = (revealLocations?() ?? [])
+            .sorted { ($0.sizeBytes ?? 0) > ($1.sizeBytes ?? 0) }
+        guard !locations.isEmpty else { return entries }
+
+        if !entries.isEmpty {
+            entries.append(.separator)
+        }
+
+        if locations.count == 1 {
+            let url = locations[0].url
+            entries.append(.action(title: "Show in Finder") { FinderReveal.show(url) })
+        } else {
+            entries.append(
+                .submenu(
+                    title: "Show in Finder",
+                    entries: locations.map { location in
+                        .action(title: FinderReveal.menuTitle(for: location)) {
+                            FinderReveal.show(location.url)
+                        }
+                    }
+                )
+            )
+        }
+
+        let urls = locations.map(\.url)
+        entries.append(
+            .action(title: urls.count == 1 ? "Copy Path" : "Copy Paths") {
+                FinderReveal.copyPaths(urls)
+            }
+        )
+
+        return entries
     }
 
     @ViewBuilder
@@ -402,14 +455,78 @@ struct ScanResultRow: View {
     }
 }
 
+// MARK: - Row accessibility actions
+
+/// Exposes the right-click actions to VoiceOver and the keyboard, which cannot produce
+/// a secondary click.
+///
+/// "Show in Finder" is a single action with a fixed name even when the row has several
+/// locations: `accessibilityAction(named:)` needs its label during `body`, so naming one
+/// action per location would force the path/size formatting we deliberately defer to
+/// right-click. It reveals the largest location — the one the visual submenu lists first.
+private struct ScanRowAccessibilityActions: ViewModifier {
+    let onExcludeFromScans: (() -> Void)?
+    let revealLocations: (() -> [ScanRowLocation])?
+
+    func body(content: Content) -> some View {
+        content
+            .modifier(OptionalAction(name: "Exclude from scans", handler: onExcludeFromScans))
+            .modifier(OptionalAction(name: "Show in Finder", handler: revealHandler))
+    }
+
+    private var revealHandler: (() -> Void)? {
+        guard let revealLocations else { return nil }
+        return {
+            let largest = revealLocations().max { ($0.sizeBytes ?? 0) < ($1.sizeBytes ?? 0) }
+            guard let largest else { return }
+            FinderReveal.show(largest.url)
+        }
+    }
+
+    private struct OptionalAction: ViewModifier {
+        let name: String
+        let handler: (() -> Void)?
+
+        func body(content: Content) -> some View {
+            if let handler {
+                content.accessibilityAction(named: Text(name), handler)
+            } else {
+                content
+            }
+        }
+    }
+}
+
 // MARK: - Row context menu
+
+/// One entry in a scan row's right-click menu.
+enum ScanRowMenuEntry {
+    case action(title: String, handler: () -> Void)
+    case submenu(title: String, entries: [ScanRowMenuEntry])
+    case separator
+}
+
+/// Retains a menu item's closure: `NSMenuItem.target` is weak, so the host view holds
+/// these for the lifetime of the open menu.
+private final class ScanRowMenuActionTarget: NSObject {
+    private let handler: () -> Void
+
+    init(handler: @escaping () -> Void) {
+        self.handler = handler
+    }
+
+    @objc func fire() {
+        handler()
+    }
+}
 
 /// Right-click menu that consumes the click so NSTableView never paints its blue row
 /// highlight. Left clicks pass through for normal row selection.
 struct ScanRowContextMenu: NSViewRepresentable {
     @Binding var isMenuActive: Bool
-    let title: String
-    let action: () -> Void
+    /// Evaluated on right-click, never during `body`. Building entries eagerly would
+    /// standardize paths and format sizes on every render of every visible row.
+    let entries: () -> [ScanRowMenuEntry]
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -427,9 +544,11 @@ struct ScanRowContextMenu: NSViewRepresentable {
 
     final class MenuHostView: NSView {
         weak var menuDelegate: NSMenuDelegate?
-        var title = ""
-        var action: () -> Void = {}
+        var entries: () -> [ScanRowMenuEntry] = { [] }
         var onMenuOpened: (() -> Void)?
+
+        /// Keeps each item's action target alive while the menu is up.
+        private var actionTargets: [ScanRowMenuActionTarget] = []
 
         override func rightMouseDown(with event: NSEvent) {
             showMenu(for: event)
@@ -441,17 +560,45 @@ struct ScanRowContextMenu: NSViewRepresentable {
         }
 
         private func showMenu(for event: NSEvent) {
+            let entries = entries()
+            guard !entries.isEmpty else { return }
             onMenuOpened?()
+            actionTargets.removeAll()
             let menu = NSMenu()
-            let item = NSMenuItem(title: title, action: #selector(performAction), keyEquivalent: "")
-            item.target = self
-            menu.addItem(item)
+            // Items carry explicit targets; without this, AppKit's validation path
+            // would grey out the submenu parents.
+            menu.autoenablesItems = false
+            populate(menu, with: entries)
             menu.delegate = menuDelegate
             menu.popUp(positioning: nil, at: convert(event.locationInWindow, from: nil), in: self)
         }
 
-        @objc private func performAction() {
-            action()
+        private func populate(_ menu: NSMenu, with entries: [ScanRowMenuEntry]) {
+            for entry in entries {
+                switch entry {
+                case .separator:
+                    menu.addItem(.separator())
+
+                case .action(let title, let handler):
+                    let target = ScanRowMenuActionTarget(handler: handler)
+                    actionTargets.append(target)
+                    let item = NSMenuItem(
+                        title: title,
+                        action: #selector(ScanRowMenuActionTarget.fire),
+                        keyEquivalent: ""
+                    )
+                    item.target = target
+                    menu.addItem(item)
+
+                case .submenu(let title, let subEntries):
+                    let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+                    let subMenu = NSMenu(title: title)
+                    subMenu.autoenablesItems = false
+                    populate(subMenu, with: subEntries)
+                    item.submenu = subMenu
+                    menu.addItem(item)
+                }
+            }
         }
 
         /// Claim secondary clicks only; every other event passes to the SwiftUI row beneath.
@@ -470,15 +617,13 @@ struct ScanRowContextMenu: NSViewRepresentable {
 
     func makeNSView(context: Context) -> MenuHostView {
         let view = MenuHostView()
-        view.title = title
-        view.action = action
+        view.entries = entries
         wire(view: view, coordinator: context.coordinator)
         return view
     }
 
     func updateNSView(_ nsView: MenuHostView, context: Context) {
-        nsView.title = title
-        nsView.action = action
+        nsView.entries = entries
         wire(view: nsView, coordinator: context.coordinator)
     }
 


### PR DESCRIPTION
Closes #15

## Problem

Scan rows showed an item's name, explanation, and size — but never its path. For a row like "Go module cache — 4.2 GB" there was no way to see *which folder* that actually is, let alone go look at it before cleaning. Large Files already had reveal-in-Finder and Quick Look; every other tab had no equivalent.

## What this adds

**Show in Finder** and **Copy Path** in the existing row right-click menu.

Nothing changes in the card itself — no location line, no chevron, no height change, no extra visual weight. The menu is built on right-click rather than during `body`, so no row pays for path standardization or size formatting while rendering.

### Single-location rows get a flat menu

<img width="1470" height="956" alt="Screenshot 2026-08-07 at 11 36 15 PM" src="https://github.com/user-attachments/assets/2df8a900-27b1-4c18-9adb-e39775a1e08e" />

### Multi-location rows get a submenu

<img width="1470" height="956" alt="Screenshot 2026-08-07 at 11 36 30 PM" src="https://github.com/user-attachments/assets/d284949f-7ba5-4314-a561-bee85fbc834b" />

Revealing every location at once would be actively unpleasant: `activateFileViewerSelecting` groups its URLs by parent directory and opens **one Finder window per distinct parent**. Cache locations for one app almost always sit under different parents (`~/Library/Application Support`, `~/Library/Caches`, `~/Library/Containers`), so passing them together fans out a burst of windows with no indication which is which.

This isn't an edge case — 127 of 212 definitions in `explanations.json` have multiple aliases or bundle IDs, so they can merge into a multi-location row.

The submenu sorts largest-first and labels each entry with path plus size, so it also quietly answers "which of these is the actual bulk?" — visible in the screenshot above, where Claude AI App's 294.1 MB breaks down to a 266.8 MB `Cache` and four much smaller folders.

## Implementation notes

- **New** `purge/Utilities/FinderReveal.swift` — reveal, copy-paths, and the submenu label helper. `show()` deliberately takes a single URL, with the multi-window reasoning documented at the call site so it doesn't get widened to an array later.
- `ScanRowContextMenu` now takes `[ScanRowMenuEntry]` (action / submenu / separator) instead of one hardcoded title + action.
- Rows take `revealLocations: (() -> [ScanRowLocation])?` — a **closure**, not an array. Building the array in `body` would standardize paths and format sizes for every visible row on every render, which is the pattern behind the tab-switch regression fixed earlier.
- Covers App Caches, dev tools, simulators, project artifacts, and project group headers (which reveal the project root).

### Two judgement calls

**Unknown sizes show no size rather than "Zero KB."** Sizes arrive asynchronously after a scan, so a location can legitimately have none yet, and `— Zero KB` reads as an empty folder rather than a pending one. Pinned by a test.

**VoiceOver gets one "Show in Finder" action, not one per location.** `accessibilityAction(named:)` needs its label during `body`, so per-location actions would force exactly the formatting work the closure defers. The single action reveals the largest location — the one the submenu lists first.

## Deliberately not included

Recursive in-app browsing, per-file checkboxes inside a cache item (partial deletion of e.g. a Go module cache leaves a state neither the tool nor Purge can reason about, and turns one honest safety verdict into thousands of unverified ones), and eager child enumeration during scan. Finder is one click away and is better at being Finder.

## Testing

- `BUILD SUCCEEDED`.
- Test suite: **278 passed, 1 failed** — the failure is `cacheSafetyStillBlocksPersonalMediaPaths`, which already fails on clean `main` and is unrelated.
- 5 new tests in `PurgeTests/FinderRevealTests.swift` covering the submenu labels (home abbreviation, absolute paths, size appending, unknown/zero size, trailing-slash normalization).
- Manually verified on a signed build: both menu shapes, submenu tracking, and reveal on a genuinely multi-location row.

### Known, pre-existing

An open `NSMenu` stalls the main queue, so browsing the submenu freezes UI updates while it's up. The previous single-item menu did this too, but a submenu tends to stay open longer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added Finder reveal actions for scan results, developer tools, simulator data, and project artifacts.
  * Added context-menu options to reveal locations in Finder and copy standardized paths.
  * Added nested location menus with path and size details.
  * Added equivalent accessibility actions for exclusion and Finder reveal.

* **Bug Fixes**
  * Improved home-directory path abbreviation to avoid incorrectly shortening similarly named sibling paths.
  * Normalized Finder menu path formatting, including trailing slashes.

* **Tests**
  * Added coverage for Finder menu titles, path formatting, size display, and trailing-slash handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->