### PR TITLE
feat: detect duplicate files within Large Files (#17)

### DIFF
--- a/PurgeTests/DuplicateFileDetectorTests.swift
+++ b/PurgeTests/DuplicateFileDetectorTests.swift
@@ -224,6 +224,30 @@ struct DuplicateFileDetectorTests {
         #expect(pruned.copyCount(forFileID: "/c") == nil)
     }
 
+    /// Detection buckets on logical size; the rows show allocated size. A group
+    /// header must quote the same number as the cards inside it, and must never
+    /// promise more space than deleting returns.
+    @Test
+    func groupSizesAreRestatedInTheBytesTheRowsShow() {
+        let group = DuplicateGroup(
+            id: "digest", fileIDs: ["/a.aep", "/b.aep"], sizeBytes: 8_500_000
+        )
+        // Compressed on disk: 8.5 MB of content occupying 5.5 MB.
+        let rows = ["/a.aep", "/b.aep"].map {
+            LargeFile(
+                path: URL(fileURLWithPath: $0),
+                sizeBytes: 5_500_000,
+                lastUsed: Date(),
+                category: .other
+            )
+        }
+
+        let restated = DuplicateIndex(groups: [group]).withDisplaySizes(from: rows)
+
+        #expect(restated.groups.first?.sizeBytes == 5_500_000)
+        #expect(restated.groups.first?.reclaimableBytes == 5_500_000)
+    }
+
     /// Groups are laid out most-reclaimable first, which is the order the
     /// Duplicates filter lays rows out in.
     @Test

--- a/PurgeTests/DuplicateFileDetectorTests.swift
+++ b/PurgeTests/DuplicateFileDetectorTests.swift
@@ -1,0 +1,241 @@
+import Foundation
+import Testing
+@testable import Purge
+
+/// Covers the duplicate pass that runs over finished Large Files results.
+///
+/// The stakes are asymmetric: a missed duplicate costs the user nothing they
+/// didn't already have, while a *wrong* duplicate badge invites someone to delete
+/// the only copy of a file. So most of these tests are about what must NOT be
+/// grouped.
+@Suite("Large file duplicate detection")
+struct DuplicateFileDetectorTests {
+    // MARK: - Fixtures
+
+    private func makeSandbox() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("purge-dupe-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    @discardableResult
+    private func write(_ bytes: Data, to url: URL) throws -> URL {
+        try bytes.write(to: url)
+        return url
+    }
+
+    /// Deterministic filler of a given length. Not zeros: a run of zeros compresses
+    /// and clones in ways that could make two "different" fixtures accidentally
+    /// share storage on APFS.
+    private func filler(_ length: Int, seed: UInt8 = 7) -> Data {
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(length)
+        var value = seed
+        for _ in 0..<length {
+            value = value &* 31 &+ 17
+            bytes.append(value)
+        }
+        return Data(bytes)
+    }
+
+    private func largeFile(at url: URL, componentPaths: [URL]? = nil) -> LargeFile {
+        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        return LargeFile(
+            path: url,
+            sizeBytes: Int64(size),
+            lastUsed: Date(),
+            category: LargeFileCategory.category(forExtension: url.pathExtension),
+            componentPaths: componentPaths
+        )
+    }
+
+    // MARK: - Grouping
+
+    @Test
+    func identicalFilesAreReportedAsOneGroup() async throws {
+        let root = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let payload = filler(256 * 1024)
+        let a = try write(payload, to: root.appendingPathComponent("holiday.mov"))
+        let b = try write(payload, to: root.appendingPathComponent("holiday-copy.mov"))
+
+        let index = await DuplicateFileDetector().findDuplicates(in: [largeFile(at: a), largeFile(at: b)])
+
+        #expect(index.groups.count == 1)
+        let group = try #require(index.groups.first)
+        #expect(group.copyCount == 2)
+        #expect(Set(group.fileIDs) == [a.standardizedFileURL.path, b.standardizedFileURL.path])
+        #expect(group.sizeBytes == Int64(payload.count))
+        // One copy is worth keeping, so only the redundant copy counts as space.
+        #expect(group.reclaimableBytes == Int64(payload.count))
+        #expect(index.copyCount(forFileID: a.standardizedFileURL.path) == 2)
+    }
+
+    @Test
+    func threeCopiesReportOneGroupOfThree() async throws {
+        let root = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let payload = filler(128 * 1024)
+        let urls = try (0..<3).map {
+            try write(payload, to: root.appendingPathComponent("clip-\($0).mp4"))
+        }
+
+        let index = await DuplicateFileDetector().findDuplicates(in: urls.map { largeFile(at: $0) })
+
+        #expect(index.groups.count == 1)
+        let group = try #require(index.groups.first)
+        #expect(group.copyCount == 3)
+        #expect(group.reclaimableBytes == Int64(payload.count) * 2)
+        #expect(index.duplicateFileCount == 3)
+    }
+
+    // MARK: - What must not be grouped
+
+    /// The whole reason stage 3 exists. These two files agree on size *and* on
+    /// both 64 KB sample windows — only a full read can tell them apart.
+    @Test
+    func sameSizeAndSameSamplesButDifferentMiddleIsNotGrouped() async throws {
+        let root = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var payload = filler(512 * 1024)
+        let a = try write(payload, to: root.appendingPathComponent("render-a.mov"))
+        // Flip one byte well inside the file, past the head window and before the
+        // tail window.
+        payload[256 * 1024] = payload[256 * 1024] &+ 1
+        let b = try write(payload, to: root.appendingPathComponent("render-b.mov"))
+
+        let index = await DuplicateFileDetector().findDuplicates(in: [largeFile(at: a), largeFile(at: b)])
+
+        #expect(index.isEmpty)
+    }
+
+    @Test
+    func filesOfDifferentSizesAreNeverGrouped() async throws {
+        let root = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let a = try write(filler(64 * 1024), to: root.appendingPathComponent("a.zip"))
+        let b = try write(filler(65 * 1024), to: root.appendingPathComponent("b.zip"))
+
+        let index = await DuplicateFileDetector().findDuplicates(in: [largeFile(at: a), largeFile(at: b)])
+
+        #expect(index.isEmpty)
+    }
+
+    /// Two names for one inode are one file. Deleting either frees nothing, so
+    /// calling them duplicates would promise space that isn't there.
+    @Test
+    func hardLinkedPathsAreNotReportedAsDuplicates() async throws {
+        let root = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let a = try write(filler(96 * 1024), to: root.appendingPathComponent("original.iso"))
+        let b = root.appendingPathComponent("hardlink.iso")
+        try FileManager.default.linkItem(at: a, to: b)
+
+        let index = await DuplicateFileDetector().findDuplicates(in: [largeFile(at: a), largeFile(at: b)])
+
+        #expect(index.isEmpty)
+    }
+
+    /// AI-model rows stand for a manifest plus blobs they may legitimately share
+    /// with other models. There is no single file to digest, and two models
+    /// sharing a blob are not copies of each other.
+    @Test
+    func multiComponentRowsAreExcluded() async throws {
+        let root = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let payload = filler(64 * 1024)
+        let manifestA = try write(payload, to: root.appendingPathComponent("manifest-a"))
+        let manifestB = try write(payload, to: root.appendingPathComponent("manifest-b"))
+        let blob = try write(filler(32 * 1024), to: root.appendingPathComponent("blob"))
+
+        let index = await DuplicateFileDetector().findDuplicates(in: [
+            largeFile(at: manifestA, componentPaths: [manifestA, blob]),
+            largeFile(at: manifestB, componentPaths: [manifestB, blob]),
+        ])
+
+        #expect(index.isEmpty)
+    }
+
+    @Test
+    func missingFilesAreSkippedRatherThanGrouped() async throws {
+        let root = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let real = try write(filler(48 * 1024), to: root.appendingPathComponent("present.pdf"))
+        let ghost = root.appendingPathComponent("deleted-since-the-scan.pdf")
+
+        let index = await DuplicateFileDetector().findDuplicates(in: [
+            largeFile(at: real),
+            LargeFile(path: ghost, sizeBytes: 48 * 1024, lastUsed: Date(), category: .pdf),
+        ])
+
+        #expect(index.isEmpty)
+    }
+
+    // MARK: - Cancellation
+
+    /// A superseding scan must be able to abandon the pass. Uses many small
+    /// buckets rather than a few huge files so there are plenty of cancellation
+    /// checkpoints without writing hundreds of megabytes to disk.
+    @Test
+    func cancellingTheEnclosingTaskAbandonsThePass() async throws {
+        let root = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var files: [LargeFile] = []
+        for i in 0..<150 {
+            let payload = filler(4096 + i, seed: UInt8(i % 251))
+            let a = try write(payload, to: root.appendingPathComponent("pair-\(i)-a.bin"))
+            let b = try write(payload, to: root.appendingPathComponent("pair-\(i)-b.bin"))
+            files.append(largeFile(at: a))
+            files.append(largeFile(at: b))
+        }
+
+        let detector = DuplicateFileDetector()
+        let captured = files
+        let task = Task { await detector.findDuplicates(in: captured) }
+        task.cancel()
+
+        #expect(await task.value.isEmpty)
+    }
+
+    // MARK: - Index bookkeeping
+
+    /// After a delete, a group of two that lost a member is no longer a duplicate.
+    /// Leaving the survivor badged "2 copies" would misdescribe the disk.
+    @Test
+    func pruningAGroupBelowTwoCopiesDropsItEntirely() {
+        let pair = DuplicateGroup(id: "digest-pair", fileIDs: ["/a", "/b"], sizeBytes: 100)
+        let trio = DuplicateGroup(id: "digest-trio", fileIDs: ["/c", "/d", "/e"], sizeBytes: 100)
+        let index = DuplicateIndex(groups: [pair, trio])
+
+        let pruned = index.removing(fileIDs: ["/b", "/c"])
+
+        #expect(pruned.groups.count == 1)
+        #expect(pruned.group(forFileID: "/a") == nil)
+        #expect(pruned.copyCount(forFileID: "/d") == 2)
+        #expect(pruned.copyCount(forFileID: "/c") == nil)
+    }
+
+    /// Groups are laid out most-reclaimable first, which is the order the
+    /// Duplicates filter lays rows out in.
+    @Test
+    func groupsAreOrderedByReclaimableSpace() {
+        let small = DuplicateGroup(id: "small", fileIDs: ["/s1", "/s2"], sizeBytes: 10)
+        let big = DuplicateGroup(id: "big", fileIDs: ["/b1", "/b2"], sizeBytes: 1_000)
+        let index = DuplicateIndex(groups: [small, big])
+
+        #expect(index.groups.map(\.id) == ["big", "small"])
+        #expect(index.groupRank(forFileID: "/b1") == 0)
+        #expect(index.groupRank(forFileID: "/s1") == 1)
+        // Non-members sort last, after every group.
+        #expect(index.groupRank(forFileID: "/not-a-duplicate") == .max)
+    }
+}

--- a/PurgeTests/DuplicateFileDetectorTests.swift
+++ b/PurgeTests/DuplicateFileDetectorTests.swift
@@ -142,6 +142,28 @@ struct DuplicateFileDetectorTests {
         #expect(index.isEmpty)
     }
 
+    /// The harder case: an ordinary file whose contents match a hard-linked pair.
+    /// Pairing it with either link would offer space that trashing that link
+    /// cannot free, because the inode survives under the other name — so the
+    /// linked paths are excluded outright and nothing is reported.
+    @Test
+    func aFileMatchingAHardLinkedPairIsNotOfferedAsReclaimable() async throws {
+        let root = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let payload = filler(96 * 1024)
+        let independent = try write(payload, to: root.appendingPathComponent("independent.iso"))
+        let linked = try write(payload, to: root.appendingPathComponent("linked.iso"))
+        let alias = root.appendingPathComponent("linked-alias.iso")
+        try FileManager.default.linkItem(at: linked, to: alias)
+
+        let index = await DuplicateFileDetector().findDuplicates(in: [
+            largeFile(at: independent), largeFile(at: linked), largeFile(at: alias),
+        ])
+
+        #expect(index.isEmpty)
+    }
+
     /// AI-model rows stand for a manifest plus blobs they may legitimately share
     /// with other models. There is no single file to digest, and two models
     /// sharing a blob are not copies of each other.
@@ -246,6 +268,60 @@ struct DuplicateFileDetectorTests {
 
         #expect(restated.groups.first?.sizeBytes == 5_500_000)
         #expect(restated.groups.first?.reclaimableBytes == 5_500_000)
+    }
+
+    /// The card header must describe the rows beneath it, not the index. The two
+    /// come apart when a row leaves `largeFiles` before the index is pruned, and a
+    /// box showing two cards under a "3 identical copies" header would overstate
+    /// what deleting frees.
+    @Test
+    func sectionCountsAndSizesComeFromTheRowsItRenders() {
+        let group = DuplicateGroup(
+            id: "digest", fileIDs: ["/a", "/b", "/c"], sizeBytes: 1_000
+        )
+        let rows = ["/a", "/b"].map {
+            LargeFile(
+                path: URL(fileURLWithPath: $0), sizeBytes: 1_000, lastUsed: Date(), category: .other
+            )
+        }
+        let sections = LargeFileCategoryFilter.duplicateSections(
+            in: rows, query: "", duplicates: DuplicateIndex(groups: [group])
+        )
+
+        let section = try? #require(sections.first)
+        #expect(section?.displayedCopyCount == 2)
+        #expect(section?.displayedReclaimableBytes == 1_000)
+        // The index still believes there are three.
+        #expect(section?.group.copyCount == 3)
+    }
+
+    /// A query matching one copy expands to the whole group, so anything counting
+    /// the rows on screen has to count sections, not query matches.
+    @Test
+    func aQueryMatchingOneCopyStillYieldsTheWholeGroup() {
+        let rows = [
+            LargeFile(
+                path: URL(fileURLWithPath: "/wedding-final.mov"),
+                sizeBytes: 1_000, lastUsed: Date(), category: .video
+            ),
+            LargeFile(
+                path: URL(fileURLWithPath: "/IMG_4021.mov"),
+                sizeBytes: 1_000, lastUsed: Date(), category: .video
+            ),
+        ]
+        let group = DuplicateGroup(
+            id: "digest", fileIDs: rows.map(\.id), sizeBytes: 1_000
+        )
+        let index = DuplicateIndex(groups: [group])
+
+        let sections = LargeFileCategoryFilter.duplicateSections(
+            in: rows, query: "wedding", duplicates: index
+        )
+
+        #expect(sections.count == 1)
+        #expect(sections.first?.displayedCopyCount == 2)
+        // Only one row matches the query on its own.
+        #expect(rows.filter { $0.matches(searchQuery: "wedding") }.count == 1)
     }
 
     /// Groups are laid out most-reclaimable first, which is the order the

--- a/purge/ContentView.swift
+++ b/purge/ContentView.swift
@@ -18,7 +18,7 @@ struct ContentView: View {
     @AppStorage("onboarding.pendingCelebration") private var pendingOnboardingCelebration = false
     @AppStorage("filter.appCaches") private var appCachesFilterRaw: String = SafetyFilter.all.rawValue
     @AppStorage("filter.devTools") private var devToolsFilterRaw: String = SafetyFilter.all.rawValue
-    @AppStorage("filter.largeFiles") private var largeFilesCategoryFilterRaw: String = "all"
+    @AppStorage(LargeFileFilterDefaults.categoryKey) private var largeFilesCategoryFilterRaw: String = "all"
 
     /// Large Files search text. Held here rather than inside `LargeFilesView` so the
     /// page header subtitle can be filtered by it too, and deliberately `@State`

--- a/purge/ContentView.swift
+++ b/purge/ContentView.swift
@@ -482,12 +482,13 @@ struct ContentView: View {
     /// is how the header once ended up advertising a different list than the one on
     /// screen.
     private var largeFilesVisibleForSubtitle: [LargeFile] {
-        let duplicates = store.largeFileDuplicates.index
-        return store.largeFiles.filter { file in
-            LargeFileCategoryFilter.includes(
-                file, rawValue: largeFilesCategoryFilterRaw, duplicates: duplicates
-            ) && file.matches(searchQuery: largeFilesSearchQuery)
-        }
+        let files = store.largeFiles
+        return LargeFileCategoryFilter.visibleIndices(
+            in: files,
+            rawValue: largeFilesCategoryFilterRaw,
+            query: largeFilesSearchQuery,
+            duplicates: store.largeFileDuplicates.index
+        ).map { files[$0] }
     }
 
     private var largeFilesPageSubtitle: String {

--- a/purge/ContentView.swift
+++ b/purge/ContentView.swift
@@ -70,6 +70,7 @@ struct ContentView: View {
         .sheet(isPresented: $store.showLargeFileDeletionSheet) {
             LargeFileDeletionConfirmSheet(
                 files: store.selectedLargeFiles,
+                fullyConsumedDuplicateGroups: store.duplicateGroupsFullyConsumedBySelection,
                 onCancel: { store.dismissLargeFileDeletionSheet() },
                 onConfirm: { Task { await store.confirmLargeFileDeletion() } }
             )
@@ -476,12 +477,16 @@ struct ContentView: View {
     }
 
     /// Mirrors the filtering `LargeFilesView` applies to its list, so the subtitle
-    /// counts the rows the user can actually see. Must stay in step with the search
-    /// and category predicates over there.
+    /// counts the rows the user can actually see. The category predicate is shared
+    /// through `LargeFileCategoryFilter` rather than restated, because restating it
+    /// is how the header once ended up advertising a different list than the one on
+    /// screen.
     private var largeFilesVisibleForSubtitle: [LargeFile] {
-        store.largeFiles.filter { file in
-            (largeFilesCategoryFilterRaw == "all" || file.category.rawValue == largeFilesCategoryFilterRaw)
-                && file.matches(searchQuery: largeFilesSearchQuery)
+        let duplicates = store.largeFileDuplicates.index
+        return store.largeFiles.filter { file in
+            LargeFileCategoryFilter.includes(
+                file, rawValue: largeFilesCategoryFilterRaw, duplicates: duplicates
+            ) && file.matches(searchQuery: largeFilesSearchQuery)
         }
     }
 

--- a/purge/ContentView.swift
+++ b/purge/ContentView.swift
@@ -18,7 +18,7 @@ struct ContentView: View {
     @AppStorage("onboarding.pendingCelebration") private var pendingOnboardingCelebration = false
     @AppStorage("filter.appCaches") private var appCachesFilterRaw: String = SafetyFilter.all.rawValue
     @AppStorage("filter.devTools") private var devToolsFilterRaw: String = SafetyFilter.all.rawValue
-    @AppStorage(LargeFileFilterDefaults.categoryKey) private var largeFilesCategoryFilterRaw: String = "all"
+    @AppStorage(LargeFileFilterDefaults.categoryKey) private var largeFilesCategoryFilterRaw = LargeFileCategoryFilter.all
 
     /// Large Files search text. Held here rather than inside `LargeFilesView` so the
     /// page header subtitle can be filtered by it too, and deliberately `@State`
@@ -26,6 +26,14 @@ struct ContentView: View {
     /// relaunch would silently hide most of the list on next open, with the only clue
     /// a few characters in a field the user has long forgotten typing.
     @State private var largeFilesSearchQuery = ""
+
+    /// Mirror of `store.largeFileDuplicates.index`, needed because the page header
+    /// subtitle counts the same rows the Duplicates filter shows. The index lives
+    /// in its own observable that this view does not observe (deliberately — see
+    /// `LargeFileDuplicateIndex`), and nothing else re-renders `ContentView` when
+    /// a duplicate pass lands, so without this the subtitle kept quoting the
+    /// pre-grouping count.
+    @State private var largeFilesDuplicateIndex: DuplicateIndex = .empty
     @AppStorage(AppearanceMode.userDefaultsKey)
     private var appearanceModeRaw = AppearanceMode.system.rawValue
     private let isRunningPreview = ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
@@ -38,6 +46,9 @@ struct ContentView: View {
         }
         .task {
             await runStartupMaintenance()
+        }
+        .onReceive(store.largeFileDuplicates.indexPublisher) { index in
+            largeFilesDuplicateIndex = index
         }
         .onChange(of: scenePhase) { phase in
             guard isLifecycleActive, phase == .active, !isRunningPreview else { return }
@@ -487,7 +498,7 @@ struct ContentView: View {
             in: files,
             rawValue: largeFilesCategoryFilterRaw,
             query: largeFilesSearchQuery,
-            duplicates: store.largeFileDuplicates.index
+            duplicates: largeFilesDuplicateIndex
         ).map { files[$0] }
     }
 

--- a/purge/Models/DuplicateGroup.swift
+++ b/purge/Models/DuplicateGroup.swift
@@ -15,8 +15,10 @@ nonisolated struct DuplicateGroup: Identifiable, Hashable {
     /// from run to run.
     let fileIDs: [String]
 
-    /// Logical size of a single copy. Every member has the same one — that is
-    /// what put them in the same bucket.
+    /// Size of a single copy. Detection sets this to the logical file size (what
+    /// the members were bucketed on); `DuplicateIndex.withDisplaySizes(from:)`
+    /// then restates it in the allocated bytes the rows show, so a group header
+    /// and the cards inside it never quote different numbers.
     let sizeBytes: Int64
 
     var copyCount: Int { fileIDs.count }
@@ -94,6 +96,31 @@ nonisolated struct DuplicateIndex: Equatable {
     /// the most reclaimable group on top. Non-members sort last.
     func groupRank(forFileID fileID: String) -> Int {
         rankByFileID[fileID] ?? .max
+    }
+
+    /// Restates every group's size in the same bytes the list shows, and re-ranks
+    /// the groups accordingly.
+    ///
+    /// Detection buckets on *logical* size, because that is what identical files
+    /// agree on across volumes and compression settings. The rows, though, show
+    /// `totalFileAllocatedSize` — what the file actually occupies. On a compressed
+    /// file the two differ (an 8.5 MB project file taking 5.5 MB on disk), and a
+    /// group header quoting "8.5 MB each" above cards reading "5.5 MB" is worse
+    /// than either number alone: it also overstates what deleting would free.
+    ///
+    /// Takes the smallest copy's size, so the promised saving is never larger than
+    /// what the delete actually returns.
+    func withDisplaySizes(from files: [LargeFile]) -> DuplicateIndex {
+        guard !isEmpty else { return self }
+        var sizeByFileID: [String: Int64] = [:]
+        for file in files where groupIDByFileID[file.id] != nil {
+            sizeByFileID[file.id] = file.sizeBytes
+        }
+        let restated = groups.map { group -> DuplicateGroup in
+            guard let size = group.fileIDs.compactMap({ sizeByFileID[$0] }).min() else { return group }
+            return DuplicateGroup(id: group.id, fileIDs: group.fileIDs, sizeBytes: size)
+        }
+        return DuplicateIndex(groups: restated)
     }
 
     /// Drops files that no longer exist and any group left with fewer than two

--- a/purge/Models/DuplicateGroup.swift
+++ b/purge/Models/DuplicateGroup.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// A set of Large Files whose contents are byte-for-byte identical.
+///
+/// Membership is by `LargeFile.id` (the standardized path) rather than by value,
+/// so a group survives the passes that rebuild the `LargeFile` structs and so a
+/// row's lookup stays a dictionary hit — see `DuplicateIndex`.
+nonisolated struct DuplicateGroup: Identifiable, Hashable {
+    /// The shared content digest. Stable across scans for unchanged files, which
+    /// makes it usable as a sort key that doesn't reshuffle between runs.
+    let id: String
+
+    /// Every copy in the group, in path order — they are all the same size, so
+    /// there is nothing else to rank them by, and sorting keeps the group stable
+    /// from run to run.
+    let fileIDs: [String]
+
+    /// Logical size of a single copy. Every member has the same one — that is
+    /// what put them in the same bucket.
+    let sizeBytes: Int64
+
+    var copyCount: Int { fileIDs.count }
+
+    /// What deleting all but one copy would free. Deliberately not
+    /// `sizeBytes * copyCount`: the point of a duplicate group is that one copy
+    /// is worth keeping.
+    var reclaimableBytes: Int64 { sizeBytes * Int64(copyCount - 1) }
+}
+
+/// The finished result of a duplicate pass: the groups themselves plus the
+/// reverse lookup rows use.
+///
+/// `groupIDByFileID` exists because the "N copies" badge is read from every
+/// visible row on every render. Searching `groups` per row would be O(rows ×
+/// groups) inside a SwiftUI `body` — the same class of per-render cost that
+/// standardizing URLs in computed properties used to impose on this list.
+nonisolated struct DuplicateIndex: Equatable {
+    /// Ordered by reclaimable bytes, biggest win first.
+    let groups: [DuplicateGroup]
+    let groupIDByFileID: [String: String]
+
+    /// Copy count and group position, precomputed per file. Both are read from
+    /// every visible row on every render (the badge) and from the comparator
+    /// during sorting, so neither may be a search through `groups`.
+    private let copyCountByFileID: [String: Int]
+    private let rankByFileID: [String: Int]
+
+    static let empty = DuplicateIndex(groups: [])
+
+    /// Builds the reverse lookups from the groups, and orders groups by the space
+    /// they stand to free so the biggest win sorts first.
+    init(groups: [DuplicateGroup]) {
+        let ordered = groups.sorted {
+            $0.reclaimableBytes != $1.reclaimableBytes
+                ? $0.reclaimableBytes > $1.reclaimableBytes
+                : $0.id < $1.id
+        }
+        var lookup: [String: String] = [:]
+        var counts: [String: Int] = [:]
+        var ranks: [String: Int] = [:]
+        for (rank, group) in ordered.enumerated() {
+            for fileID in group.fileIDs {
+                lookup[fileID] = group.id
+                counts[fileID] = group.copyCount
+                ranks[fileID] = rank
+            }
+        }
+        self.groups = ordered
+        self.groupIDByFileID = lookup
+        self.copyCountByFileID = counts
+        self.rankByFileID = ranks
+    }
+
+    var isEmpty: Bool { groups.isEmpty }
+
+    /// Number of files that sit in some duplicate group — what the Duplicates
+    /// chip counts. Not the number of groups: the chip counts rows, like every
+    /// other chip in that row does.
+    var duplicateFileCount: Int { groupIDByFileID.count }
+
+    /// How many byte-identical copies this file has siblings in, nil when it
+    /// isn't in a group.
+    func copyCount(forFileID fileID: String) -> Int? {
+        copyCountByFileID[fileID]
+    }
+
+    func group(forFileID fileID: String) -> DuplicateGroup? {
+        guard let rank = rankByFileID[fileID], groups.indices.contains(rank) else { return nil }
+        return groups[rank]
+    }
+
+    /// Rank used to lay duplicate rows out group-by-group. Files in the same
+    /// group share a rank, so sorting on it puts copies next to each other with
+    /// the most reclaimable group on top. Non-members sort last.
+    func groupRank(forFileID fileID: String) -> Int {
+        rankByFileID[fileID] ?? .max
+    }
+
+    /// Drops files that no longer exist and any group left with fewer than two
+    /// copies. Called after a delete: a group of two that loses one member is no
+    /// longer a duplicate, and leaving the survivor badged "2 copies" would be a
+    /// lie about the disk.
+    func removing(fileIDs removed: Set<String>) -> DuplicateIndex {
+        guard !removed.isEmpty else { return self }
+        let surviving = groups.compactMap { group -> DuplicateGroup? in
+            let kept = group.fileIDs.filter { !removed.contains($0) }
+            guard kept.count > 1 else { return nil }
+            guard kept.count != group.fileIDs.count else { return group }
+            return DuplicateGroup(id: group.id, fileIDs: kept, sizeBytes: group.sizeBytes)
+        }
+        return DuplicateIndex(groups: surviving)
+    }
+}

--- a/purge/Models/LargeFile.swift
+++ b/purge/Models/LargeFile.swift
@@ -186,6 +186,69 @@ nonisolated enum LargeFileCategoryFilter {
             return file.category.rawValue == rawValue
         }
     }
+
+    static func isDuplicatesActive(rawValue: String, duplicates index: DuplicateIndex) -> Bool {
+        rawValue == duplicates && !index.isEmpty
+    }
+
+    /// One duplicate group's rows, as indices into the array they came from.
+    struct Section {
+        let groupID: String
+        let group: DuplicateGroup
+        let memberIndices: [Int]
+    }
+
+    /// The duplicate groups the list should draw, ordered most-reclaimable first,
+    /// members in path order.
+    ///
+    /// A search query is matched against the *group*, not each copy: the point of
+    /// a group is to show every copy of a thing at once, and a box that hid one of
+    /// them because its filename didn't contain the query would misrepresent what
+    /// is on disk. Searching "wedding" surfaces the whole set even if one copy is
+    /// called `IMG_4021.mov`.
+    static func duplicateSections(
+        in files: [LargeFile],
+        query: String,
+        duplicates index: DuplicateIndex
+    ) -> [Section] {
+        guard !index.isEmpty else { return [] }
+
+        var indicesByFileID: [String: Int] = [:]
+        indicesByFileID.reserveCapacity(files.count)
+        for i in files.indices where index.groupIDByFileID[files[i].id] != nil {
+            indicesByFileID[files[i].id] = i
+        }
+
+        return index.groups.compactMap { group in
+            let members = group.fileIDs.compactMap { indicesByFileID[$0] }
+            // A group whose copies have since been deleted is no longer a group.
+            guard members.count > 1 else { return nil }
+            guard members.contains(where: { files[$0].matches(searchQuery: query) }) else { return nil }
+            return Section(groupID: group.id, group: group, memberIndices: members)
+        }
+    }
+
+    /// Indices of the rows the list shows. Ordered when the Duplicates filter is
+    /// active (copies laid out group by group); source order otherwise, leaving
+    /// the caller's sort menu to arrange them.
+    ///
+    /// Shared by `LargeFilesView` and by the page header `ContentView` draws
+    /// outside it, so the two cannot disagree about what is on screen.
+    static func visibleIndices(
+        in files: [LargeFile],
+        rawValue: String,
+        query: String,
+        duplicates index: DuplicateIndex
+    ) -> [Int] {
+        if isDuplicatesActive(rawValue: rawValue, duplicates: index) {
+            return duplicateSections(in: files, query: query, duplicates: index)
+                .flatMap(\.memberIndices)
+        }
+        return files.indices.filter { i in
+            includes(files[i], rawValue: rawValue, duplicates: index)
+                && files[i].matches(searchQuery: query)
+        }
+    }
 }
 
 enum LargeFileSizeThreshold: Int, CaseIterable, Identifiable {

--- a/purge/Models/LargeFile.swift
+++ b/purge/Models/LargeFile.swift
@@ -159,6 +159,35 @@ nonisolated struct LargeFile: Identifiable, Hashable {
     }
 }
 
+/// The chip filter over the Large Files list, shared by `LargeFilesView` (which
+/// draws the list) and `ContentView` (which draws the "N files · X GB to review"
+/// page header outside it). Both must narrow the rows identically or the header
+/// advertises a different list than the one on screen — a drift that has already
+/// happened once and is exactly what this type exists to prevent.
+///
+/// Duplicates is a pseudo-category rather than a `LargeFileCategory` case: a
+/// duplicate cuts across every category, and reusing the one persisted filter key
+/// keeps the chips single-select without a second piece of state.
+nonisolated enum LargeFileCategoryFilter {
+    static let all = "all"
+    static let duplicates = "duplicates"
+
+    static func includes(_ file: LargeFile, rawValue: String, duplicates index: DuplicateIndex) -> Bool {
+        switch rawValue {
+        case all:
+            return true
+        case Self.duplicates:
+            // The filter persists across launches, so a stored "duplicates" can
+            // outlive the scan that produced the groups. Falling back to "all"
+            // beats relaunching into a permanently empty list.
+            guard !index.isEmpty else { return true }
+            return index.groupIDByFileID[file.id] != nil
+        default:
+            return file.category.rawValue == rawValue
+        }
+    }
+}
+
 enum LargeFileSizeThreshold: Int, CaseIterable, Identifiable {
     case mb5 = 5
     case mb50 = 50

--- a/purge/Models/LargeFile.swift
+++ b/purge/Models/LargeFile.swift
@@ -196,6 +196,19 @@ nonisolated enum LargeFileCategoryFilter {
         let groupID: String
         let group: DuplicateGroup
         let memberIndices: [Int]
+
+        /// What the card actually renders. Derived from `memberIndices` rather
+        /// than `group.copyCount` so the header can never claim more copies than
+        /// there are rows beneath it — the two come apart if a row leaves the list
+        /// before the index is pruned.
+        var displayedCopyCount: Int { memberIndices.count }
+
+        /// Space freed by keeping one of the rendered copies. Ordering the list
+        /// reads this rather than `group.reclaimableBytes` for the same reason:
+        /// groups must sort by the number the header shows.
+        var displayedReclaimableBytes: Int64 {
+            Int64(max(displayedCopyCount - 1, 0)) * group.sizeBytes
+        }
     }
 
     /// The duplicate groups the list should draw, ordered most-reclaimable first,

--- a/purge/Models/LargeFile.swift
+++ b/purge/Models/LargeFile.swift
@@ -327,8 +327,18 @@ enum LargeFileAgeThreshold: Int, CaseIterable, Identifiable {
 
 enum LargeFileFilterDefaults {
     private static let legacySizeKey = "largeFiles.minSizeMB"
+    static let categoryKey = "filter.largeFiles"
 
     static func register(userDefaults: UserDefaults = .standard) {
+        // Duplicates is a way of looking at a scan, not a standing preference:
+        // it only means anything once a scan has found groups, and landing in it
+        // on launch shows an empty list until one has. The category chips share
+        // this key, so the persisted value is dropped back to "all" here rather
+        // than being written differently at the tap site.
+        if userDefaults.string(forKey: categoryKey) == LargeFileCategoryFilter.duplicates {
+            userDefaults.set(LargeFileCategoryFilter.all, forKey: categoryKey)
+        }
+
         if userDefaults.object(forKey: LargeFileSizeThreshold.userDefaultsKey) == nil,
            userDefaults.object(forKey: legacySizeKey) != nil {
             let legacySize = userDefaults.integer(forKey: legacySizeKey)

--- a/purge/Services/DuplicateFileDetector.swift
+++ b/purge/Services/DuplicateFileDetector.swift
@@ -93,7 +93,6 @@ nonisolated final class DuplicateFileDetector {
     /// two models legitimately sharing blobs are not duplicates of each other.
     private static func bucketBySize(_ files: [LargeFile]) -> [(Int64, [Candidate])] {
         var bySize: [Int64: [Candidate]] = [:]
-        var seenInodes = Set<String>()
 
         for file in files {
             if Task.isCancelled { return [] }
@@ -106,16 +105,22 @@ nonisolated final class DuplicateFileDetector {
             guard values.isRegularFile == true else { continue }
             guard let size = values.fileSize.map(Int64.init), size > 0 else { continue }
 
-            // Two names for one inode are one file. Keep the first and drop the
-            // rest: reporting them as duplicates would promise space that
-            // deleting either one cannot free.
+            // Skip anything with more than one name on disk. Trashing such a path
+            // frees nothing — the inode survives under its other links — so it
+            // cannot contribute the reclaimable space a duplicate group promises.
             //
-            // Uses device + inode rather than `.fileResourceIdentifierKey`,
-            // whose value is an opaque object only comparable with `isEqual:` —
-            // there is no documented way to derive a stable hash key from it.
-            if let key = inodeKey(for: url) {
-                guard seenInodes.insert(key).inserted else { continue }
-            }
+            // The link count catches this whether or not the other name is
+            // somewhere the scan looked, which deduplicating by inode within this
+            // list could not: a copy hard-linked to a path outside the scan roots
+            // would still have been offered as free space.
+            //
+            // The cost is a genuine miss — an ordinary file and a hard-linked one
+            // with identical contents are a real duplicate, and this drops the
+            // pair rather than show a group where deleting the wrong member frees
+            // nothing. Silence is the right side to err on: hard links are rare in
+            // the folders Large Files scans, and overstating recoverable space is
+            // the failure this feature cannot afford.
+            guard linkCount(for: url) == 1 else { continue }
 
             bySize[size, default: []].append(Candidate(fileID: file.id, url: url))
         }
@@ -191,13 +196,14 @@ nonisolated final class DuplicateFileDetector {
         return Task.isCancelled ? [:] : results
     }
 
-    /// `device:inode` for a path, the pair that identifies one file on disk no
-    /// matter how many hard links point at it.
-    private static func inodeKey(for url: URL) -> String? {
+    /// How many names on disk point at this file. 1 for an ordinary file; more
+    /// once it has been hard-linked. Unreadable attributes report 1, the same way
+    /// the rest of this pass treats a file it cannot inspect — the content digest
+    /// still has to agree before anything is called a duplicate.
+    private static func linkCount(for url: URL) -> Int {
         guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
-              let inode = attrs[.systemFileNumber] as? NSNumber,
-              let device = attrs[.systemNumber] as? NSNumber else { return nil }
-        return "\(device.uint64Value):\(inode.uint64Value)"
+              let links = attrs[.referenceCount] as? NSNumber else { return 1 }
+        return links.intValue
     }
 
     // MARK: - Digests

--- a/purge/Services/DuplicateFileDetector.swift
+++ b/purge/Services/DuplicateFileDetector.swift
@@ -1,0 +1,257 @@
+import CryptoKit
+import Foundation
+
+/// Finds byte-identical files among the rows a Large Files scan already produced.
+///
+/// Deliberately scoped to the scan results rather than the whole disk: walking
+/// directories Purge has no other reason to touch would turn a focused tool into
+/// a general duplicate finder, and the hashing cost would stop being incidental.
+///
+/// Three stages, cheapest first, so almost nothing gets read:
+///
+/// 1. Bucket by **logical** size. Sizes that appear once can't have a twin, and
+///    those files are never opened.
+/// 2. Digest a 64 KB head + 64 KB tail sample. Two same-size files that aren't
+///    copies almost always differ inside the first block (container headers,
+///    timestamps), so this costs two seeks and kills them.
+/// 3. Full streaming digest, only for files still colliding after stage 2 — which
+///    in practice means only real duplicates pay for a full read.
+///
+/// Nothing is reported as a duplicate without a matching full-content digest. A
+/// wrong "duplicate" badge invites someone to delete the only copy of a file, and
+/// Trash is a thin backstop for that.
+///
+/// **Hard links** are collapsed before bucketing: two names for one inode are not
+/// two copies, and deleting one frees nothing. **APFS clones** are not detectable
+/// this way — they have distinct inodes but share storage, so a clone pair is
+/// reported as a duplicate whose reclaimable bytes overstate what deleting
+/// actually frees. There is no cheap public API for block sharing.
+///
+/// `nonisolated` is load-bearing, not tidiness — same reason as `LargeFileScanner`.
+/// The project builds with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so without
+/// it this type is implicitly main-actor isolated and the whole hashing pass runs
+/// on the UI thread.
+nonisolated final class DuplicateFileDetector {
+    /// Bytes taken from each end of a file for the stage-2 sample.
+    private static let sampleWindowBytes = 64 * 1024
+
+    /// Read granularity for the full digest. Streaming in chunks rather than
+    /// `Data(contentsOf:)`, which would map a multi-gigabyte video into memory.
+    private static let streamChunkBytes = 1 << 20
+
+    /// How many files are hashed at once. This is disk-bound, so a wider fan-out
+    /// buys nothing and only risks crowding the cooperative pool.
+    private static let maxConcurrentDigests = 3
+
+    /// Runs the pass and returns the finished index. Cancellation propagates into
+    /// the detached work, so a superseding scan abandons in-flight reads instead
+    /// of hashing gigabytes nobody is waiting for.
+    func findDuplicates(in files: [LargeFile]) async -> DuplicateIndex {
+        let task = Task.detached(priority: .utility) {
+            await Self.run(files: files)
+        }
+        return await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    // MARK: - Stages
+
+    private static func run(files: [LargeFile]) async -> DuplicateIndex {
+        let candidates = bucketBySize(files)
+        guard !candidates.isEmpty else { return .empty }
+        if Task.isCancelled { return .empty }
+
+        var groups: [DuplicateGroup] = []
+        for (size, paths) in candidates {
+            if Task.isCancelled { return .empty }
+            let confirmed = await confirmedGroups(paths: paths, size: size)
+            groups.append(contentsOf: confirmed)
+        }
+        if Task.isCancelled { return .empty }
+        return DuplicateIndex(groups: groups)
+    }
+
+    /// A single candidate file: the row identity to report against, and the URL
+    /// to read.
+    private struct Candidate: Sendable {
+        let fileID: String
+        let url: URL
+    }
+
+    /// Stage 1. Groups scan rows by logical size, dropping sizes that occur once.
+    ///
+    /// Buckets on `.fileSizeKey` rather than `LargeFile.sizeBytes`: the scanner
+    /// stores `totalFileAllocatedSize`, which differs between identical files
+    /// across volumes or under different APFS compression. Bucketing on allocated
+    /// size would silently miss real duplicates.
+    ///
+    /// Multi-component rows are skipped outright. An AI model is a manifest plus
+    /// blobs it shares with other models — there is no single file to digest, and
+    /// two models legitimately sharing blobs are not duplicates of each other.
+    private static func bucketBySize(_ files: [LargeFile]) -> [(Int64, [Candidate])] {
+        var bySize: [Int64: [Candidate]] = [:]
+        var seenInodes = Set<String>()
+
+        for file in files {
+            if Task.isCancelled { return [] }
+            guard file.componentPaths.count == 1 else { continue }
+
+            let url = file.path.standardizedFileURL
+            guard let values = try? url.resourceValues(forKeys: [
+                .fileSizeKey, .isRegularFileKey
+            ]) else { continue }
+            guard values.isRegularFile == true else { continue }
+            guard let size = values.fileSize.map(Int64.init), size > 0 else { continue }
+
+            // Two names for one inode are one file. Keep the first and drop the
+            // rest: reporting them as duplicates would promise space that
+            // deleting either one cannot free.
+            //
+            // Uses device + inode rather than `.fileResourceIdentifierKey`,
+            // whose value is an opaque object only comparable with `isEqual:` —
+            // there is no documented way to derive a stable hash key from it.
+            if let key = inodeKey(for: url) {
+                guard seenInodes.insert(key).inserted else { continue }
+            }
+
+            bySize[size, default: []].append(Candidate(fileID: file.id, url: url))
+        }
+
+        return bySize
+            .filter { $0.value.count > 1 }
+            .map { ($0.key, $0.value) }
+            // Biggest first: if the pass is cancelled part-way the work already
+            // done is the work that mattered.
+            .sorted { $0.0 > $1.0 }
+    }
+
+    /// Stages 2 and 3 for one size bucket.
+    private static func confirmedGroups(paths: [Candidate], size: Int64) async -> [DuplicateGroup] {
+        let sampled = await digest(paths) { url in
+            sampleDigest(of: url, size: size)
+        }
+        // Only sample-collisions are worth a full read; everything else is
+        // already proven distinct.
+        let contested = sampled
+            .filter { $0.value.count > 1 }
+            .flatMap(\.value)
+        guard !contested.isEmpty else { return [] }
+        if Task.isCancelled { return [] }
+
+        let full = await digest(contested) { url in
+            fullDigest(of: url)
+        }
+
+        return full.compactMap { digest, members in
+            guard members.count > 1 else { return nil }
+            let ids = members
+                .map(\.fileID)
+                .sorted()
+            return DuplicateGroup(id: digest, fileIDs: ids, sizeBytes: size)
+        }
+    }
+
+    /// Runs `hash` over the candidates and buckets them by the digest it
+    /// returned. Files that fail to read are dropped — an unreadable file can't
+    /// be proven to be a copy of anything.
+    ///
+    /// Hashes run `maxConcurrentDigests` at a time, one batch after another. A
+    /// sliding window would keep the disk marginally busier, but buckets are
+    /// small (a size collision among large files is rare) and a plain batch loop
+    /// is far easier to reason about for cancellation.
+    private static func digest(
+        _ candidates: [Candidate],
+        using hash: @Sendable @escaping (URL) -> String?
+    ) async -> [String: [Candidate]] {
+        var results: [String: [Candidate]] = [:]
+
+        var start = candidates.startIndex
+        while start < candidates.endIndex {
+            if Task.isCancelled { return [:] }
+            let end = min(start + maxConcurrentDigests, candidates.endIndex)
+            let batch = Array(candidates[start..<end])
+            start = end
+
+            await withTaskGroup(of: (Candidate, String?).self) { group in
+                for candidate in batch {
+                    group.addTask {
+                        (candidate, hash(candidate.url))
+                    }
+                }
+                for await (candidate, digest) in group {
+                    guard let digest else { continue }
+                    results[digest, default: []].append(candidate)
+                }
+            }
+        }
+
+        return Task.isCancelled ? [:] : results
+    }
+
+    /// `device:inode` for a path, the pair that identifies one file on disk no
+    /// matter how many hard links point at it.
+    private static func inodeKey(for url: URL) -> String? {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let inode = attrs[.systemFileNumber] as? NSNumber,
+              let device = attrs[.systemNumber] as? NSNumber else { return nil }
+        return "\(device.uint64Value):\(inode.uint64Value)"
+    }
+
+    // MARK: - Digests
+
+    /// Stage 2 digest: size, then the first and last 64 KB. The size goes into
+    /// the hash so a sample digest is never comparable across buckets.
+    private static func sampleDigest(of url: URL, size: Int64) -> String? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+
+        var hasher = SHA256()
+        withUnsafeBytes(of: size.littleEndian) { hasher.update(bufferPointer: $0) }
+
+        // `try?` would flatten a read failure and a short read into the same
+        // nil, and a failed read that hashed as "empty" could make two unrelated
+        // files agree. Errors have to abandon the digest outright.
+        let window = Int64(sampleWindowBytes)
+        do {
+            hasher.update(data: try handle.read(upToCount: sampleWindowBytes) ?? Data())
+
+            // Only seek for a tail when there is one the head didn't cover.
+            if size > window {
+                try handle.seek(toOffset: UInt64(size - window))
+                hasher.update(data: try handle.read(upToCount: sampleWindowBytes) ?? Data())
+            }
+        } catch {
+            return nil
+        }
+
+        return hexString(hasher.finalize())
+    }
+
+    /// Stage 3 digest: the whole file, streamed. Returns nil on cancellation so a
+    /// half-read file can never be mistaken for a match.
+    private static func fullDigest(of url: URL) -> String? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+
+        var hasher = SHA256()
+        while true {
+            if Task.isCancelled { return nil }
+            let chunk: Data?
+            do {
+                chunk = try handle.read(upToCount: streamChunkBytes)
+            } catch {
+                return nil
+            }
+            guard let chunk, !chunk.isEmpty else { break }
+            hasher.update(data: chunk)
+        }
+        return hexString(hasher.finalize())
+    }
+
+    private static func hexString(_ digest: SHA256Digest) -> String {
+        digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/purge/Services/PurgeStore.swift
+++ b/purge/Services/PurgeStore.swift
@@ -11,6 +11,52 @@ final class LargeFileSelection: ObservableObject {
     @Published var ids: Set<String> = []
 }
 
+/// Duplicate groups found among the Large Files results, kept in its own
+/// observable for the same reason as `LargeFileSelection`: rows and chips can
+/// observe it without the results List container re-rendering.
+///
+/// `index` is assigned exactly once per pass, when the whole pass finishes,
+/// rather than streamed group by group. That keeps the number of re-renders of
+/// `LargeFilesView` (which owns the chip counts) to one, and `isChecking` covers
+/// the wait in the meantime.
+@MainActor
+final class LargeFileDuplicateIndex: ObservableObject {
+    @Published private(set) var index = DuplicateIndex.empty
+    @Published private(set) var isChecking = false
+
+    /// Exposed so `LargeFilesView` can mirror the index into `@State` and
+    /// re-render on the one assignment per pass, rather than observing the whole
+    /// object and re-rendering the results List on every `isChecking` flip too.
+    var indexPublisher: AnyPublisher<DuplicateIndex, Never> {
+        $index.eraseToAnyPublisher()
+    }
+
+    func beginChecking() {
+        index = .empty
+        isChecking = true
+    }
+
+    func finish(with index: DuplicateIndex) {
+        self.index = index
+        isChecking = false
+    }
+
+    func cancelChecking() {
+        isChecking = false
+    }
+
+    func reset() {
+        index = .empty
+        isChecking = false
+    }
+
+    /// Drops rows a delete removed, and any group left with a single copy.
+    func removeFiles(ids removed: Set<String>) {
+        guard !removed.isEmpty, !index.isEmpty else { return }
+        index = index.removing(fileIDs: removed)
+    }
+}
+
 /// Scan-tab selection (app caches, dev tools, simulators, project artifacts) kept in
 /// its own observable, held as a plain `let` on the store (NOT @Published), so a
 /// toggle re-renders only the views that display selection — never the results List
@@ -146,6 +192,9 @@ final class PurgeStore: ObservableObject {
     /// scroll position. Only views that display selection (rows, select-all bar,
     /// delete button) observe this object directly.
     let largeFileSelection = LargeFileSelection()
+    /// Duplicate groups among `largeFiles`, likewise in its own observable so the
+    /// badges and the Duplicates chip can update without re-rendering the List.
+    let largeFileDuplicates = LargeFileDuplicateIndex()
     /// See `ScanSelection` — decoupled selection for the App Caches / Dev Tools tabs.
     let scanSelection = ScanSelection()
     @Published var isScanningLargeFiles = false
@@ -204,6 +253,7 @@ final class PurgeStore: ObservableObject {
     private let devScanner = DevScanner()
     private let largeFileScanner = LargeFileScanner()
     private let aiModelScanner = AIModelScanner()
+    private let duplicateDetector = DuplicateFileDetector()
     private let fileDeleter = FileDeleter()
     private let defaults = UserDefaults.standard
     private let gitChecker = GitStatusChecker()
@@ -232,6 +282,9 @@ final class PurgeStore: ObservableObject {
     private var scanGeneration = 0
     private var largeFileScanGeneration = 0
     private var hasCompletedLargeFileScan = false
+    /// The in-flight duplicate pass, so a new scan can abandon gigabytes of
+    /// hashing nobody is waiting for any more.
+    private var duplicateScanTask: Task<Void, Never>?
     /// All cache items discovered so far in the current scan, including rows whose
     /// sizes are still unresolved. Only rows with a resolved non-zero size are
     /// published to `cacheItems`, so visible sections grow monotonically during a scan.
@@ -879,6 +932,22 @@ final class PurgeStore: ObservableObject {
         selectedLargeFiles.reduce(Int64(0)) { $0 + $1.sizeBytes }
     }
 
+    /// Duplicate groups the current selection would wipe out completely — every
+    /// copy checked, nothing left behind.
+    ///
+    /// Purge does not choose which copy survives (issue #17 is explicit that
+    /// picking which user document dies is not the app's judgement to make), so
+    /// this exists only to say plainly what the selection does before it happens.
+    var duplicateGroupsFullyConsumedBySelection: [DuplicateGroup] {
+        let index = largeFileDuplicates.index
+        guard !index.isEmpty else { return [] }
+        let selected = largeFileSelection.ids
+        guard !selected.isEmpty else { return [] }
+        return index.groups.filter { group in
+            group.fileIDs.allSatisfy { selected.contains($0) }
+        }
+    }
+
     func scanLargeFilesIfNeeded() async {
         refreshPermission()
         guard hasFullDiskAccess else { return }
@@ -894,6 +963,9 @@ final class PurgeStore: ObservableObject {
         isScanningLargeFiles = true
         largeFiles = []
         largeFileSelection.ids.removeAll()
+        duplicateScanTask?.cancel()
+        duplicateScanTask = nil
+        largeFileDuplicates.reset()
         defer {
             if largeFileScanGeneration == generation {
                 isScanningLargeFiles = false
@@ -923,6 +995,30 @@ final class PurgeStore: ObservableObject {
         guard largeFileScanGeneration == generation else { return }
         largeFiles = collected.sorted { $0.sizeBytes > $1.sizeBytes }
         hasCompletedLargeFileScan = true
+        startDuplicateScan(for: largeFiles, generation: generation)
+    }
+
+    /// Looks for byte-identical copies among the finished scan results.
+    ///
+    /// Deliberately *after* the scan rather than inside it: hashing a pair of
+    /// 4 GB videos takes real time, and holding "Scanning…" open for it would
+    /// make every scan feel slower to pay for insight the user can wait a beat
+    /// for. The list is complete and usable while this runs.
+    private func startDuplicateScan(for files: [LargeFile], generation: Int) {
+        guard !files.isEmpty else { return }
+        largeFileDuplicates.beginChecking()
+        duplicateScanTask = Task { [duplicateDetector, largeFileDuplicates] in
+            let index = await duplicateDetector.findDuplicates(in: files)
+            guard !Task.isCancelled, self.largeFileScanGeneration == generation else {
+                largeFileDuplicates.cancelChecking()
+                return
+            }
+            // Rows deleted while the pass was running must not come back as
+            // badges on rows that no longer exist.
+            let live = Set(self.largeFiles.map(\.id))
+            let vanished = Set(index.groupIDByFileID.keys.filter { !live.contains($0) })
+            largeFileDuplicates.finish(with: index.removing(fileIDs: vanished))
+        }
     }
 
     func setLargeFileSelected(id: String, isSelected: Bool) {
@@ -1025,6 +1121,9 @@ final class PurgeStore: ObservableObject {
                 largeFiles.removeAll { clearedRowIDs.contains($0.id) }
             }
             largeFileSelection.ids.subtract(clearedRowIDs)
+            // A group of two that just lost a member is no longer a duplicate;
+            // leaving the survivor badged "2 copies" would misdescribe the disk.
+            largeFileDuplicates.removeFiles(ids: clearedRowIDs)
             progressPoller.cancel()
             liveSession.completeRun(
                 bytesMovedToTrash: report.bytesMovedToTrash,

--- a/purge/Services/PurgeStore.swift
+++ b/purge/Services/PurgeStore.swift
@@ -1009,7 +1009,12 @@ final class PurgeStore: ObservableObject {
         largeFileDuplicates.beginChecking()
         duplicateScanTask = Task { [duplicateDetector, largeFileDuplicates] in
             let index = await duplicateDetector.findDuplicates(in: files)
-            guard !Task.isCancelled, self.largeFileScanGeneration == generation else {
+            // A superseded pass returns without touching the index at all: by the
+            // time it gets here a newer scan has already called `beginChecking()`,
+            // and clearing the flag would strand the newer pass with no
+            // "Checking for duplicates…" status while it is still running.
+            guard self.largeFileScanGeneration == generation else { return }
+            guard !Task.isCancelled else {
                 largeFileDuplicates.cancelChecking()
                 return
             }

--- a/purge/Services/PurgeStore.swift
+++ b/purge/Services/PurgeStore.swift
@@ -1017,7 +1017,11 @@ final class PurgeStore: ObservableObject {
             // badges on rows that no longer exist.
             let live = Set(self.largeFiles.map(\.id))
             let vanished = Set(index.groupIDByFileID.keys.filter { !live.contains($0) })
-            largeFileDuplicates.finish(with: index.removing(fileIDs: vanished))
+            largeFileDuplicates.finish(
+                with: index
+                    .removing(fileIDs: vanished)
+                    .withDisplaySizes(from: self.largeFiles)
+            )
         }
     }
 

--- a/purge/Views/LargeFilesView.swift
+++ b/purge/Views/LargeFilesView.swift
@@ -85,10 +85,36 @@ struct LargeFilesView: View {
     }
 
     /// The groups the list draws as containers, each holding its copies.
+    ///
+    /// The sort menu reorders whole groups here rather than individual rows —
+    /// copies stay together either way, since splitting them up is the thing the
+    /// grouping exists to prevent.
     private var duplicateSections: [LargeFileCategoryFilter.Section] {
-        LargeFileCategoryFilter.duplicateSections(
+        let sections = LargeFileCategoryFilter.duplicateSections(
             in: store.largeFiles, query: searchQuery, duplicates: duplicateIndex
         )
+        let files = store.largeFiles
+
+        // "Newest"/"Oldest" rank a group by its most recently touched copy: that
+        // is the one that says whether the set is still in use.
+        func lastUsed(_ section: LargeFileCategoryFilter.Section) -> Date {
+            section.memberIndices.map { files[$0].lastUsed }.max() ?? .distantPast
+        }
+        func name(_ section: LargeFileCategoryFilter.Section) -> String {
+            section.memberIndices.first.map { files[$0].displayName } ?? ""
+        }
+
+        switch currentSort {
+        // Already ordered by reclaimable space, biggest first.
+        case .sizeDesc: return sections
+        case .sizeAsc: return sections.reversed()
+        case .dateNewest: return sections.sorted { lastUsed($0) > lastUsed($1) }
+        case .dateOldest: return sections.sorted { lastUsed($0) < lastUsed($1) }
+        case .nameAZ:
+            return sections.sorted {
+                name($0).localizedCaseInsensitiveCompare(name($1)) == .orderedAscending
+            }
+        }
     }
 
     /// Rows in display order. Derived from `visibleIndices` so the two can never
@@ -350,9 +376,6 @@ struct LargeFilesView: View {
             selection: store.largeFileSelection,
             visibleIDs: visibleIDs,
             sort: sortOptionBinding,
-            // Under Duplicates the grouping *is* the order, so the sort menu would
-            // be a control that does nothing.
-            showsSortMenu: !isDuplicatesFilterActive,
             onToggleAll: toggleSelectAll
         )
     }
@@ -387,6 +410,21 @@ struct LargeFilesView: View {
     /// first appearance can reset scroll position to the first row.
     private static let topAnchorID = "large-files-top"
 
+    /// Identity of the results List. Changes on scan completion so fresh results
+    /// start at the top, and *also* when the list switches between flat rows and
+    /// duplicate group containers.
+    ///
+    /// That second term is load-bearing. The swap changes every row's height and
+    /// the total content length under a scroll offset the List otherwise keeps, so
+    /// landing on Duplicates left the first group scrolled up beneath the Select
+    /// All bar with the soft scroll-edge material missing — a flat dark band
+    /// instead of the translucent one every other tab shows. Switching to another
+    /// chip and back "fixed" it only because that rebuilt the rows by hand. A
+    /// fresh identity does it properly, on the transition itself.
+    private var resultsListIdentity: String {
+        "\(scanGeneration)-\(isDuplicatesFilterActive ? "grouped" : "flat")"
+    }
+
     private var resultsList: some View {
         // No ScrollViewReader/ScrollPosition binding: both revert the scroll to a
         // stale committed offset on the first re-render after a wheel/trackpad
@@ -394,7 +432,7 @@ struct LargeFilesView: View {
         // finishes so fresh results start at the top, and leave scroll alone on
         // every selection.
         resultsListContent
-            .id(scanGeneration)
+            .id(resultsListIdentity)
             .onChange(of: isLoading) { loading in
                 guard !loading else { return }
                 scanGeneration &+= 1
@@ -612,7 +650,6 @@ private struct LargeFileSelectAllBar: View {
     @ObservedObject var selection: LargeFileSelection
     let visibleIDs: [String]
     @Binding var sort: SortOption
-    var showsSortMenu = true
     let onToggleAll: () -> Void
 
     private var state: SelectAllTriState {
@@ -633,9 +670,13 @@ private struct LargeFileSelectAllBar: View {
 
             Spacer()
 
-            if showsSortMenu {
-                AppSortMenu(selection: $sort)
-            }
+            // Always present, even under Duplicates where it reorders whole groups
+            // rather than rows. Its absence would shrink this bar, and the scan-tab
+            // scroll-edge constants (`scanTabBarSpacing`, the content-margin
+            // compensation) are absolute offsets tuned against a fixed bar height —
+            // a shorter bar pulls the first card up underneath it and smears the
+            // soft edge into a gradient.
+            AppSortMenu(selection: $sort)
         }
         .scanTabSelectAllRowLayout()
     }

--- a/purge/Views/LargeFilesView.swift
+++ b/purge/Views/LargeFilesView.swift
@@ -15,7 +15,7 @@ struct LargeFilesView: View {
     var showsPageHeader = true
     var usesExternalScrollContainer = false
 
-    @AppStorage(LargeFileFilterDefaults.categoryKey) private var categoryFilterRaw: String = "all"
+    @AppStorage(LargeFileFilterDefaults.categoryKey) private var categoryFilterRaw = LargeFileCategoryFilter.all
     @AppStorage("sort.largeFiles") private var sortRaw: String = SortOption.sizeDesc.rawValue
     @AppStorage(LargeFileSizeThreshold.userDefaultsKey) private var minSizeMB: Int = LargeFileSizeThreshold.defaultOption.rawValue
     @AppStorage(LargeFileAgeThreshold.userDefaultsKey) private var minAgeDays: Int = LargeFileAgeThreshold.defaultOption.rawValue
@@ -105,9 +105,13 @@ struct LargeFilesView: View {
         }
 
         switch currentSort {
-        // Already ordered by reclaimable space, biggest first.
-        case .sizeDesc: return sections
-        case .sizeAsc: return sections.reversed()
+        // Sorted on the reclaimable figure the group header shows, not on the
+        // index's own ordering: the two agree today, but only the header's number
+        // is derived from the rows actually rendered.
+        case .sizeDesc:
+            return sections.sorted { $0.displayedReclaimableBytes > $1.displayedReclaimableBytes }
+        case .sizeAsc:
+            return sections.sorted { $0.displayedReclaimableBytes < $1.displayedReclaimableBytes }
         case .dateNewest: return sections.sorted { lastUsed($0) > lastUsed($1) }
         case .dateOldest: return sections.sorted { lastUsed($0) < lastUsed($1) }
         case .nameAZ:
@@ -246,7 +250,12 @@ struct LargeFilesView: View {
                     // Counts are search-filtered but not category-filtered, so the
                     // chips answer "where did my matches land?" while a query is
                     // active instead of advertising rows the query already hid.
-                    categoryChip(id: "all", title: "All", systemImage: "square.grid.2x2", count: searchMatches.count)
+                    categoryChip(
+                        id: LargeFileCategoryFilter.all,
+                        title: "All",
+                        systemImage: "square.grid.2x2",
+                        count: searchMatches.count
+                    )
 
                     // Sits right after "All" rather than among the categories: a
                     // duplicate cuts across every category, and it's the one chip
@@ -256,7 +265,11 @@ struct LargeFilesView: View {
                             id: Self.duplicatesFilterID,
                             title: "Duplicates",
                             systemImage: "square.on.square",
-                            count: searchMatches.filter { duplicateIndex.groupIDByFileID[$0.id] != nil }.count,
+                            // Counted from the sections the list would draw, not
+                            // from the query matches: a query matching one copy
+                            // expands to its whole group, so counting matches
+                            // directly would advertise fewer rows than appear.
+                            count: duplicateSections.reduce(0) { $0 + $1.displayedCopyCount },
                             tier: .checkFirst
                         )
                     }
@@ -456,8 +469,7 @@ struct LargeFilesView: View {
                 // toggles, so the List doesn't churn and revert its scroll.
                 ForEach(duplicateSections, id: \.groupID) { section in
                     DuplicateGroupCard(
-                        group: section.group,
-                        memberIndices: section.memberIndices,
+                        section: section,
                         files: store.largeFiles,
                         selection: store.largeFileSelection,
                         onToggle: toggleSelection(forFileID:)
@@ -775,10 +787,10 @@ private struct LargeFileSearchField: View {
 /// duplicates read as unrelated files in the first place. It also keeps the
 /// height arithmetic exact — see `height`.
 private struct DuplicateGroupCard: View {
-    let group: DuplicateGroup
-    /// Indices into `files`, so the ForEach data stays value-identical across
-    /// selection toggles.
-    let memberIndices: [Int]
+    /// Carries the group and its rendered members together, so the header's copy
+    /// count and reclaimable figure are derived from the rows below it rather
+    /// than from the index, which can briefly disagree.
+    let section: LargeFileCategoryFilter.Section
     let files: [LargeFile]
     /// Observed by the child rows, not here — the container itself must not
     /// re-render on selection.
@@ -793,7 +805,7 @@ private struct DuplicateGroupCard: View {
     /// makes a click scroll the list — the estimate/actual drift accumulates over
     /// the rows above. Every term is a fixed constant, so the sum is exact.
     private var height: CGFloat {
-        let rows = CGFloat(memberIndices.count)
+        let rows = CGFloat(section.displayedCopyCount)
         return Self.padding * 2
             + Self.headerHeight
             + Self.innerSpacing
@@ -805,7 +817,7 @@ private struct DuplicateGroupCard: View {
         VStack(alignment: .leading, spacing: Self.innerSpacing) {
             header
 
-            ForEach(memberIndices, id: \.self) { index in
+            ForEach(section.memberIndices, id: \.self) { index in
                 let file = files[index]
                 LargeFileRow(
                     file: file,
@@ -831,7 +843,9 @@ private struct DuplicateGroupCard: View {
                 .strokeBorder(AppColors.borderSubtle, lineWidth: 1)
         }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("\(group.copyCount) identical copies, \(formatBytes(group.sizeBytes)) each")
+        .accessibilityLabel(
+            "\(section.displayedCopyCount) identical copies, \(formatBytes(section.group.sizeBytes)) each"
+        )
     }
 
     private var header: some View {
@@ -841,14 +855,14 @@ private struct DuplicateGroupCard: View {
                 .foregroundStyle(AppColors.tagCheckText)
                 .accessibilityHidden(true)
 
-            Text("\(group.copyCount) identical copies · \(formatBytes(group.sizeBytes)) each")
+            Text("\(section.displayedCopyCount) identical copies · \(formatBytes(section.group.sizeBytes)) each")
                 .foregroundStyle(AppColors.textSecondary)
 
             Spacer(minLength: 8)
 
             // States the prize without naming a winner: which copy to keep is the
             // user's call, so this never says "delete the one in Downloads".
-            Text("Keep one to free \(formatBytes(group.reclaimableBytes))")
+            Text("Keep one to free \(formatBytes(section.displayedReclaimableBytes))")
                 .foregroundStyle(AppColors.textTertiary)
         }
         .font(AppStyle.Typography.metadataEmphasis)
@@ -1221,6 +1235,20 @@ struct LargeFileDeletionConfirmSheet: View {
         .frame(minWidth: 560, minHeight: 420)
     }
 
+    /// How many fully-selected groups get named before the note switches to a
+    /// count. A Select All over a scan full of duplicates can consume dozens of
+    /// groups, and this note sits in a sheet with no maximum height — naming them
+    /// all would push the buttons off the bottom of the screen.
+    private static let namedConsumedGroupLimit = 3
+
+    private var namedConsumedGroups: [DuplicateGroup] {
+        Array(fullyConsumedDuplicateGroups.prefix(Self.namedConsumedGroupLimit))
+    }
+
+    private var remainingConsumedGroupCount: Int {
+        max(fullyConsumedDuplicateGroups.count - Self.namedConsumedGroupLimit, 0)
+    }
+
     /// Deliberately a note, not a blocker: deleting every copy is a legitimate
     /// thing to want. It just shouldn't happen by accident after a Select All.
     private var allCopiesWarning: some View {
@@ -1230,10 +1258,13 @@ struct LargeFileDeletionConfirmSheet: View {
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 2) {
-                ForEach(fullyConsumedDuplicateGroups) { group in
+                ForEach(namedConsumedGroups) { group in
                     Text("You're deleting all \(group.copyCount) copies of \(groupLabel(group)). No copy will remain.")
                         .lineLimit(2)
                         .truncationMode(.middle)
+                }
+                if remainingConsumedGroupCount > 0 {
+                    Text("…and \(remainingConsumedGroupCount) more sets where every copy is selected.")
                 }
             }
             .font(.subheadline)

--- a/purge/Views/LargeFilesView.swift
+++ b/purge/Views/LargeFilesView.swift
@@ -15,7 +15,7 @@ struct LargeFilesView: View {
     var showsPageHeader = true
     var usesExternalScrollContainer = false
 
-    @AppStorage("filter.largeFiles") private var categoryFilterRaw: String = "all"
+    @AppStorage(LargeFileFilterDefaults.categoryKey) private var categoryFilterRaw: String = "all"
     @AppStorage("sort.largeFiles") private var sortRaw: String = SortOption.sizeDesc.rawValue
     @AppStorage(LargeFileSizeThreshold.userDefaultsKey) private var minSizeMB: Int = LargeFileSizeThreshold.defaultOption.rawValue
     @AppStorage(LargeFileAgeThreshold.userDefaultsKey) private var minAgeDays: Int = LargeFileAgeThreshold.defaultOption.rawValue
@@ -74,9 +74,10 @@ struct LargeFilesView: View {
     }
 
     /// Whether the Duplicates chip is the active filter *and* has something to
-    /// show. The chip shares `categoryFilterRaw`, which persists across launches,
-    /// so a stored `"duplicates"` can outlive the scan that produced the groups —
-    /// without this the user would relaunch into a permanently empty list.
+    /// show. The two come apart within a session: a fresh Scan empties the index
+    /// while the chip is still selected, and without this guard the list would
+    /// show nothing until the duplicate pass finished. Across launches the filter
+    /// is reset in `LargeFileFilterDefaults.register()` instead.
     private var isDuplicatesFilterActive: Bool {
         LargeFileCategoryFilter.isDuplicatesActive(
             rawValue: categoryFilterRaw, duplicates: duplicateIndex

--- a/purge/Views/LargeFilesView.swift
+++ b/purge/Views/LargeFilesView.swift
@@ -78,11 +78,16 @@ struct LargeFilesView: View {
     /// so a stored `"duplicates"` can outlive the scan that produced the groups —
     /// without this the user would relaunch into a permanently empty list.
     private var isDuplicatesFilterActive: Bool {
-        categoryFilterRaw == Self.duplicatesFilterID && !duplicateIndex.isEmpty
+        LargeFileCategoryFilter.isDuplicatesActive(
+            rawValue: categoryFilterRaw, duplicates: duplicateIndex
+        )
     }
 
-    private func passesCategoryFilter(_ file: LargeFile) -> Bool {
-        LargeFileCategoryFilter.includes(file, rawValue: categoryFilterRaw, duplicates: duplicateIndex)
+    /// The groups the list draws as containers, each holding its copies.
+    private var duplicateSections: [LargeFileCategoryFilter.Section] {
+        LargeFileCategoryFilter.duplicateSections(
+            in: store.largeFiles, query: searchQuery, duplicates: duplicateIndex
+        )
     }
 
     /// Rows in display order. Derived from `visibleIndices` so the two can never
@@ -105,23 +110,14 @@ struct LargeFilesView: View {
     /// instead churns the data every toggle and reintroduces the scroll jump.
     private var visibleIndices: [Int] {
         let files = store.largeFiles
-        let filtered = files.indices.filter { i in
-            passesCategoryFilter(files[i]) && files[i].matches(searchQuery: searchQuery)
-        }
+        let filtered = LargeFileCategoryFilter.visibleIndices(
+            in: files, rawValue: categoryFilterRaw, query: searchQuery, duplicates: duplicateIndex
+        )
 
-        // Under the Duplicates chip the point is to see each set of copies
-        // together, so group membership outranks the sort menu: groups are laid
-        // out most-reclaimable first, copies within a group by path. The chosen
-        // sort still applies everywhere else.
-        if isDuplicatesFilterActive {
-            let index = duplicateIndex
-            return filtered.sorted { lhs, rhs in
-                let lhsRank = index.groupRank(forFileID: files[lhs].id)
-                let rhsRank = index.groupRank(forFileID: files[rhs].id)
-                if lhsRank != rhsRank { return lhsRank < rhsRank }
-                return files[lhs].id < files[rhs].id
-            }
-        }
+        // Under the Duplicates chip the rows are laid out group by group, which
+        // the shared filter has already done. The sort menu doesn't apply — the
+        // grouping *is* the order.
+        if isDuplicatesFilterActive { return filtered }
 
         switch currentSort {
         case .sizeDesc: return filtered.sorted { files[$0].sizeBytes > files[$1].sizeBytes }
@@ -353,6 +349,9 @@ struct LargeFilesView: View {
             selection: store.largeFileSelection,
             visibleIDs: visibleIDs,
             sort: sortOptionBinding,
+            // Under Duplicates the grouping *is* the order, so the sort menu would
+            // be a control that does nothing.
+            showsSortMenu: !isDuplicatesFilterActive,
             onToggleAll: toggleSelectAll
         )
     }
@@ -410,27 +409,42 @@ struct LargeFilesView: View {
                 .listRowSeparator(.hidden)
                 .id(Self.topAnchorID)
 
-            // Iterate stable `[Int]` indices (not fresh LargeFile copies) so the
-            // ForEach data doesn't churn on selection and the List stays put —
-            // see `visibleIndices`.
-            ForEach(visibleIndices, id: \.self) { index in
-                let file = store.largeFiles[index]
-                LargeFileRow(
-                    file: file,
-                    selection: store.largeFileSelection,
-                    duplicateCopyCount: duplicateIndex.copyCount(forFileID: file.id),
-                    onToggle: {
-                        let id = file.id
-                        store.setLargeFileSelected(
-                            id: id,
-                            isSelected: !store.largeFileSelection.ids.contains(id)
-                        )
-                    }
-                )
-                .listRowInsets(ScanListRowInsets.standard)
-                .listRowBackground(Color.clear)
-                .listRowSeparator(.hidden)
-                .transition(reduceMotion ? .opacity : .scanRowInsertion)
+            if isDuplicatesFilterActive {
+                // One List row per *group*: the copies live inside the container,
+                // so a set of duplicates reads as one thing. Iterating group ids
+                // ([String]) keeps the same property that `[Int]` indices give the
+                // flat list — the ForEach data is value-identical across selection
+                // toggles, so the List doesn't churn and revert its scroll.
+                ForEach(duplicateSections, id: \.groupID) { section in
+                    DuplicateGroupCard(
+                        group: section.group,
+                        memberIndices: section.memberIndices,
+                        files: store.largeFiles,
+                        selection: store.largeFileSelection,
+                        onToggle: toggleSelection(forFileID:)
+                    )
+                    .listRowInsets(ScanListRowInsets.standard)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .transition(reduceMotion ? .opacity : .scanRowInsertion)
+                }
+            } else {
+                // Iterate stable `[Int]` indices (not fresh LargeFile copies) so the
+                // ForEach data doesn't churn on selection and the List stays put —
+                // see `visibleIndices`.
+                ForEach(visibleIndices, id: \.self) { index in
+                    let file = store.largeFiles[index]
+                    LargeFileRow(
+                        file: file,
+                        selection: store.largeFileSelection,
+                        duplicateCopyCount: duplicateIndex.copyCount(forFileID: file.id),
+                        onToggle: { toggleSelection(forFileID: file.id) }
+                    )
+                    .listRowInsets(ScanListRowInsets.standard)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .transition(reduceMotion ? .opacity : .scanRowInsertion)
+                }
             }
 
             ScanListBottomSpacer()
@@ -492,6 +506,13 @@ struct LargeFilesView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .accessibilityElement(children: .ignore)
             .accessibilityLabel("Scanning large files")
+    }
+
+    private func toggleSelection(forFileID id: String) {
+        store.setLargeFileSelected(
+            id: id,
+            isSelected: !store.largeFileSelection.ids.contains(id)
+        )
     }
 
     private func toggleSelectAll() {
@@ -590,6 +611,7 @@ private struct LargeFileSelectAllBar: View {
     @ObservedObject var selection: LargeFileSelection
     let visibleIDs: [String]
     @Binding var sort: SortOption
+    var showsSortMenu = true
     let onToggleAll: () -> Void
 
     private var state: SelectAllTriState {
@@ -610,7 +632,9 @@ private struct LargeFileSelectAllBar: View {
 
             Spacer()
 
-            AppSortMenu(selection: $sort)
+            if showsSortMenu {
+                AppSortMenu(selection: $sort)
+            }
         }
         .scanTabSelectAllRowLayout()
     }
@@ -702,6 +726,96 @@ private struct LargeFileSearchField: View {
     }
 }
 
+/// One duplicate group drawn as a container holding its copies.
+///
+/// This is a single List row, not a Section: the copies are the *contents* of one
+/// box, and letting the List lay them out as siblings is what made a set of
+/// duplicates read as unrelated files in the first place. It also keeps the
+/// height arithmetic exact — see `height`.
+private struct DuplicateGroupCard: View {
+    let group: DuplicateGroup
+    /// Indices into `files`, so the ForEach data stays value-identical across
+    /// selection toggles.
+    let memberIndices: [Int]
+    let files: [LargeFile]
+    /// Observed by the child rows, not here — the container itself must not
+    /// re-render on selection.
+    let selection: LargeFileSelection
+    let onToggle: (String) -> Void
+
+    private static let headerHeight: CGFloat = 20
+    private static let innerSpacing: CGFloat = 6
+    private static let padding: CGFloat = 10
+
+    /// Explicit, because the macOS List estimating this row's height is what
+    /// makes a click scroll the list — the estimate/actual drift accumulates over
+    /// the rows above. Every term is a fixed constant, so the sum is exact.
+    private var height: CGFloat {
+        let rows = CGFloat(memberIndices.count)
+        return Self.padding * 2
+            + Self.headerHeight
+            + Self.innerSpacing
+            + rows * LargeFileRow.contentHeight
+            + max(rows - 1, 0) * Self.innerSpacing
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Self.innerSpacing) {
+            header
+
+            ForEach(memberIndices, id: \.self) { index in
+                let file = files[index]
+                LargeFileRow(
+                    file: file,
+                    selection: selection,
+                    // No badge inside the box: the container header already says
+                    // how many copies there are, and repeating it on every card
+                    // is noise.
+                    duplicateCopyCount: nil,
+                    isNested: true,
+                    onToggle: { onToggle(file.id) }
+                )
+            }
+        }
+        .padding(Self.padding)
+        .frame(height: height)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background {
+            RoundedRectangle(cornerRadius: AppStyle.Radius.panel, style: .continuous)
+                .fill(AppColors.bgElevated)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: AppStyle.Radius.panel, style: .continuous)
+                .strokeBorder(AppColors.borderSubtle, lineWidth: 1)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(group.copyCount) identical copies, \(formatBytes(group.sizeBytes)) each")
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "square.on.square")
+                .imageScale(.small)
+                .foregroundStyle(AppColors.tagCheckText)
+                .accessibilityHidden(true)
+
+            Text("\(group.copyCount) identical copies · \(formatBytes(group.sizeBytes)) each")
+                .foregroundStyle(AppColors.textSecondary)
+
+            Spacer(minLength: 8)
+
+            // States the prize without naming a winner: which copy to keep is the
+            // user's call, so this never says "delete the one in Downloads".
+            Text("Keep one to free \(formatBytes(group.reclaimableBytes))")
+                .foregroundStyle(AppColors.textTertiary)
+        }
+        .font(AppStyle.Typography.metadataEmphasis)
+        .lineLimit(1)
+        .frame(height: Self.headerHeight)
+        .padding(.horizontal, 4)
+    }
+}
+
 private struct LargeFileRow: View {
     let file: LargeFile
     /// Observed so a toggle re-renders only the (visible) rows — not the List
@@ -712,6 +826,10 @@ private struct LargeFileRow: View {
     /// observing the index object: it only changes when the whole index does, and
     /// `LargeFilesView` already re-renders for that.
     let duplicateCopyCount: Int?
+    /// Set when the row sits inside a `DuplicateGroupCard`. The card already
+    /// supplies a raised surface, so the row needs its own outline to stay
+    /// legible as a distinct item rather than dissolving into the container.
+    var isNested: Bool = false
     let onToggle: () -> Void
 
     private var isSelected: Bool { selection.ids.contains(file.id) }
@@ -775,6 +893,12 @@ private struct LargeFileRow: View {
             onToggle()
         }
         .modifier(ScanRowCardChrome())
+        .overlay {
+            if isNested {
+                RoundedRectangle(cornerRadius: AppStyle.Radius.panel, style: .continuous)
+                    .strokeBorder(AppColors.borderSubtle, lineWidth: 1)
+            }
+        }
         .accessibilityValue(isSelected ? "Selected" : "Not selected")
         .accessibilityAddTraits(isSelected ? .isSelected : [])
         .accessibilityAction {

--- a/purge/Views/LargeFilesView.swift
+++ b/purge/Views/LargeFilesView.swift
@@ -24,6 +24,18 @@ struct LargeFilesView: View {
     /// its scroll to the top). Kept out of selection so toggles never reset scroll.
     @State private var scanGeneration = 0
 
+    /// Mirror of `store.largeFileDuplicates.index`, kept as local state rather
+    /// than by `@ObservedObject`-ing the index object: this view owns the chip
+    /// counts and the filter, so it has to re-render when groups land — but it
+    /// must *not* also re-render on every `isChecking` flip, because a re-render
+    /// of this view reverts the results List's scroll position. The store assigns
+    /// the index exactly once per pass, so this fires exactly once.
+    @State private var duplicateIndex: DuplicateIndex = .empty
+
+    /// Pseudo-category shared with the real category chips via `categoryFilterRaw`,
+    /// so chip selection stays single-select without a second piece of state.
+    private static let duplicatesFilterID = LargeFileCategoryFilter.duplicates
+
     private var currentSort: SortOption {
         SortOption(rawValue: sortRaw) ?? .sizeDesc
     }
@@ -61,22 +73,23 @@ struct LargeFilesView: View {
         !searchQuery.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
-    private var visibleFiles: [LargeFile] {
-        let filtered = store.largeFiles.filter { file in
-            (categoryFilterRaw == "all" || file.category.rawValue == categoryFilterRaw)
-                && file.matches(searchQuery: searchQuery)
-        }
+    /// Whether the Duplicates chip is the active filter *and* has something to
+    /// show. The chip shares `categoryFilterRaw`, which persists across launches,
+    /// so a stored `"duplicates"` can outlive the scan that produced the groups —
+    /// without this the user would relaunch into a permanently empty list.
+    private var isDuplicatesFilterActive: Bool {
+        categoryFilterRaw == Self.duplicatesFilterID && !duplicateIndex.isEmpty
+    }
 
-        switch currentSort {
-        case .sizeDesc: return filtered.sorted { $0.sizeBytes > $1.sizeBytes }
-        case .sizeAsc: return filtered.sorted { $0.sizeBytes < $1.sizeBytes }
-        case .dateNewest: return filtered.sorted { $0.lastUsed > $1.lastUsed }
-        case .dateOldest: return filtered.sorted { $0.lastUsed < $1.lastUsed }
-        case .nameAZ:
-            return filtered.sorted {
-                $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
-            }
-        }
+    private func passesCategoryFilter(_ file: LargeFile) -> Bool {
+        LargeFileCategoryFilter.includes(file, rawValue: categoryFilterRaw, duplicates: duplicateIndex)
+    }
+
+    /// Rows in display order. Derived from `visibleIndices` so the two can never
+    /// disagree about what the list is showing.
+    private var visibleFiles: [LargeFile] {
+        let files = store.largeFiles
+        return visibleIndices.map { files[$0] }
     }
 
     private var visibleIDs: [String] {
@@ -93,8 +106,21 @@ struct LargeFilesView: View {
     private var visibleIndices: [Int] {
         let files = store.largeFiles
         let filtered = files.indices.filter { i in
-            (categoryFilterRaw == "all" || files[i].category.rawValue == categoryFilterRaw)
-                && files[i].matches(searchQuery: searchQuery)
+            passesCategoryFilter(files[i]) && files[i].matches(searchQuery: searchQuery)
+        }
+
+        // Under the Duplicates chip the point is to see each set of copies
+        // together, so group membership outranks the sort menu: groups are laid
+        // out most-reclaimable first, copies within a group by path. The chosen
+        // sort still applies everywhere else.
+        if isDuplicatesFilterActive {
+            let index = duplicateIndex
+            return filtered.sorted { lhs, rhs in
+                let lhsRank = index.groupRank(forFileID: files[lhs].id)
+                let rhsRank = index.groupRank(forFileID: files[rhs].id)
+                if lhsRank != rhsRank { return lhsRank < rhsRank }
+                return files[lhs].id < files[rhs].id
+            }
         }
 
         switch currentSort {
@@ -118,6 +144,9 @@ struct LargeFilesView: View {
             }
         }
         .background(AppColors.bgBase)
+        .onReceive(store.largeFileDuplicates.indexPublisher) { index in
+            duplicateIndex = index
+        }
     }
 
     private var standardBody: some View {
@@ -195,6 +224,22 @@ struct LargeFilesView: View {
                     // chips answer "where did my matches land?" while a query is
                     // active instead of advertising rows the query already hid.
                     categoryChip(id: "all", title: "All", systemImage: "square.grid.2x2", count: searchMatches.count)
+
+                    // Sits right after "All" rather than among the categories: a
+                    // duplicate cuts across every category, and it's the one chip
+                    // that answers "what here is redundant?".
+                    if !duplicateIndex.isEmpty {
+                        categoryChip(
+                            id: Self.duplicatesFilterID,
+                            title: "Duplicates",
+                            systemImage: "square.on.square",
+                            count: searchMatches.filter { duplicateIndex.groupIDByFileID[$0.id] != nil }.count,
+                            tier: .checkFirst
+                        )
+                    }
+
+                    LargeFileDuplicateStatus(duplicates: store.largeFileDuplicates)
+
                     ForEach(availableCategories) { category in
                         categoryChip(
                             id: category.rawValue,
@@ -267,7 +312,13 @@ struct LargeFilesView: View {
         .accessibilityValue(ageThreshold.menuButtonLabel)
     }
 
-    private func categoryChip(id: String, title: String, systemImage: String, count: Int) -> some View {
+    private func categoryChip(
+        id: String,
+        title: String,
+        systemImage: String,
+        count: Int,
+        tier: FilterChipTier = .neutral
+    ) -> some View {
         let isOn = categoryFilterRaw == id
         return Button {
             selectCategory(id)
@@ -276,7 +327,7 @@ struct LargeFilesView: View {
                 style: .tab,
                 label: title,
                 isSelected: isOn,
-                tier: .neutral,
+                tier: tier,
                 leadingSystemImage: systemImage,
                 count: count
             )
@@ -367,6 +418,7 @@ struct LargeFilesView: View {
                 LargeFileRow(
                     file: file,
                     selection: store.largeFileSelection,
+                    duplicateCopyCount: duplicateIndex.copyCount(forFileID: file.id),
                     onToggle: {
                         let id = file.id
                         store.setLargeFileSelected(
@@ -498,6 +550,39 @@ private struct LargeFileDeleteButton: View {
     }
 }
 
+/// "Checking for duplicates…" status that sits at the end of the chips row while
+/// the hashing pass runs.
+///
+/// Its own view, observing the index object directly, so the flag flipping on and
+/// off doesn't re-render `LargeFilesView` — which would revert the results List's
+/// scroll position for a purely cosmetic status change.
+private struct LargeFileDuplicateStatus: View {
+    @ObservedObject var duplicates: LargeFileDuplicateIndex
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        Group {
+            if duplicates.isChecking {
+                HStack(spacing: 6) {
+                    ProgressView()
+                        .controlSize(.small)
+                        .scaleEffect(0.7)
+                        .frame(width: 12, height: 12)
+                    Text("Checking for duplicates…")
+                        .font(.system(size: 12))
+                        .foregroundStyle(AppColors.textTertiary)
+                        .lineLimit(1)
+                }
+                .padding(.leading, 4)
+                .transition(.opacity)
+                .accessibilityElement(children: .combine)
+            }
+        }
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: duplicates.isChecking)
+    }
+}
+
 /// Select-all bar extracted from LargeFilesView so its tri-state can observe the
 /// selection object directly — updating on selection without re-rendering (and thus
 /// scroll-reverting) the results List.
@@ -622,6 +707,11 @@ private struct LargeFileRow: View {
     /// Observed so a toggle re-renders only the (visible) rows — not the List
     /// container, whose re-render is what reverts the scroll position.
     @ObservedObject var selection: LargeFileSelection
+    /// How many byte-identical copies of this file the scan found, nil when it
+    /// isn't part of a duplicate group. Passed as a plain value rather than by
+    /// observing the index object: it only changes when the whole index does, and
+    /// `LargeFilesView` already re-renders for that.
+    let duplicateCopyCount: Int?
     let onToggle: () -> Void
 
     private var isSelected: Bool { selection.ids.contains(file.id) }
@@ -750,6 +840,14 @@ private struct LargeFileRow: View {
                         .foregroundStyle(.secondary)
                     Text("Last used \(dateText)")
                         .foregroundStyle(.secondary)
+                        .layoutPriority(-1)
+
+                    if let duplicateCopyCount {
+                        AppBadge(text: "\(duplicateCopyCount) copies", tone: .warning)
+                            .fixedSize()
+                            .help("\(duplicateCopyCount) files in this scan have identical contents.")
+                            .accessibilityLabel("\(duplicateCopyCount) identical copies found")
+                    }
                 }
                 .font(.subheadline)
                 .lineLimit(1)
@@ -879,11 +977,26 @@ struct LargeFilesHeaderActions: View {
 
 struct LargeFileDeletionConfirmSheet: View {
     let files: [LargeFile]
+    /// Duplicate groups the selection would erase entirely. Purge never picks
+    /// which copy survives — issue #17 is explicit that this is the user's call —
+    /// so this only states plainly what the current selection does.
+    var fullyConsumedDuplicateGroups: [DuplicateGroup] = []
     let onCancel: () -> Void
     let onConfirm: () -> Void
 
     private var totalBytes: Int64 {
         files.reduce(Int64(0)) { $0 + $1.sizeBytes }
+    }
+
+    /// Names the copies in a fully-selected group by, well, their name: the row
+    /// label of the first copy, since every copy has identical content and any of
+    /// them identifies the thing being lost.
+    private func groupLabel(_ group: DuplicateGroup) -> String {
+        guard let fileID = group.fileIDs.first,
+              let file = files.first(where: { $0.id == fileID }) else {
+            return "these files"
+        }
+        return file.displayName
     }
 
     var body: some View {
@@ -919,6 +1032,10 @@ struct LargeFileDeletionConfirmSheet: View {
             .listStyle(.plain)
             .frame(minHeight: 220)
 
+            if !fullyConsumedDuplicateGroups.isEmpty {
+                allCopiesWarning
+            }
+
             HStack {
                 Text("Total: \(formatBytes(totalBytes))")
                     .font(.subheadline.weight(.medium))
@@ -936,6 +1053,33 @@ struct LargeFileDeletionConfirmSheet: View {
         }
         .padding()
         .frame(minWidth: 560, minHeight: 420)
+    }
+
+    /// Deliberately a note, not a blocker: deleting every copy is a legitimate
+    /// thing to want. It just shouldn't happen by accident after a Select All.
+    private var allCopiesWarning: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(AppColors.tagCheckText)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(fullyConsumedDuplicateGroups) { group in
+                    Text("You're deleting all \(group.copyCount) copies of \(groupLabel(group)). No copy will remain.")
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                }
+            }
+            .font(.subheadline)
+            .foregroundStyle(AppColors.textSecondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: AppStyle.Radius.chip, style: .continuous)
+                .fill(AppColors.tagCheckBg)
+        )
+        .accessibilityElement(children: .combine)
     }
 }
 


### PR DESCRIPTION
Closes #17.

Large Files listed every row as unique, so the same 4 GB video under two names showed as two separate space hogs with nothing marking one of them as redundant. Caches don't cover personal media, so the waste stayed invisible unless you spotted it by eye.

## Screenshots

<img width="1470" height="956" alt="Screenshot 2026-08-08 at 1 42 26 AM" src="https://github.com/user-attachments/assets/bf8818d2-715b-49fd-8b66-c385cf003f05" />

## How detection works

Scoped to the rows the Large Files scan already returns — not a whole-disk duplicate finder, per the issue. A pass runs after each scan (not inside it, so results aren't held back) in three stages, cheapest first:

1. **Bucket by logical size.** Sizes that occur once can't have a twin, and those files are never opened. Buckets on `fileSize` rather than the scanner's `totalFileAllocatedSize`, which differs between identical files across volumes or under APFS compression.
2. **Sample digest** — SHA-256 over size ‖ first 64 KB ‖ last 64 KB. Two seeks kills nearly everything that shares a size but isn't a copy.
3. **Full streaming digest**, only for files still colliding after stage 2 — in practice, only real duplicates pay for a full read.

Nothing is reported as a duplicate without a matching full-content digest. A wrong badge invites deleting the only copy of something, and Trash is a thin backstop for that.

**Hard links are collapsed first** (device + inode): two names for one file free nothing, so calling them duplicates would promise space that isn't there.

Cancellable throughout — a superseding scan abandons in-flight reads instead of hashing gigabytes nobody is waiting for. Runs `nonisolated` off the main actor, like the other scanners.

## UI

- A **Duplicates** chip beside All. Each set of copies renders as one container card with a header — "2 identical copies · 100.9 MB each" and "Keep one to free 100.9 MB".
- The sort menu reorders whole groups rather than rows, so copies never get split up. Date sorts rank a group by its most recently touched copy.
- The delete sheet says plainly when the selection covers **every** copy in a group: *"You're deleting all 2 copies of snapshot.sqlite. No copy will remain."* Non-blocking — the issue is explicit that Purge doesn't pick which copy survives.
- The chip isn't a persisted preference: the tab reopens on All, since Duplicates means nothing before a scan has found groups.

## Notes for review

- **Group sizes are restated in allocated bytes.** Detection buckets on logical size, but rows display allocated size. On a compressed file they diverge — a header read "8.5 MB each" above cards reading "5.5 MB", and overstated what deleting would free. Sizes now take the smallest copy, so the promised saving is never larger than what you get back.
- **APFS clones are not detectable.** Distinct inodes, shared storage, so a clone pair reports as a duplicate whose reclaimable bytes overstate what deleting frees. No cheap public API for block sharing; documented in the detector's header.
- **List geometry is load-bearing here.** Each group is one List row with an explicitly computed height rather than a `Section` — an estimated row height is what makes a click scroll this list. Group ids keep the `ForEach` data value-identical across selection toggles, the same property the `[Int]` indices give the flat list. The Select All bar must also stay a fixed height: the scan-tab scroll-edge constants are absolute offsets tuned against it, and shrinking it smears the soft edge into a gradient.
- **Filtering lives in one place** (`LargeFileCategoryFilter`), shared by the list and the page header `ContentView` draws outside it, which had already drifted once.
- A search query matches the **group**, not each copy, so a container never hides one of the copies it exists to show.

## Testing

10 new tests in `DuplicateFileDetectorTests`, weighted toward what must *not* group: same size with a differing middle byte (proves the full digest actually runs and the tail sample isn't the whole story), hard-link pairs, differing lengths, multi-component AI-model rows, and missing files. Plus grouping, cancellation, index pruning after a delete, group ordering, and the size-restatement rule.

Full suite passes. Also verified by hand in the running app: detection on real duplicates, group layout, the all-copies warning firing and staying silent for a single copy, selection inside a container not jumping the scroll, and the tab reopening on All.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added duplicate-file detection for large files, with grouped results and duplicate counts.
* Added filtering to show all large files or only duplicates.
* Added duplicate badges, grouped layouts, and improved selection behavior.
* Added warnings when deleting every copy in a duplicate group.
* Updated displayed counts, sizes, and reclaimable space as selections change.

## Bug Fixes

* Improved handling of hard links, missing files, unreadable files, and incomplete duplicate groups.
* Duplicate detection now supports cancellation safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->