### PR TITLE
feat: check for updates automatically (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ Purge needs Full Disk Access to scan your cache folders.
 
 ## Updating
 
-Purge updates itself in place. Open the **About** screen and click **Check for Updates**: if a newer version exists, Purge downloads it, verifies its signature, installs it, and relaunches. You don't need to visit the release page or drag anything.
+Purge updates itself in place. Once a day it checks for a new version, and when one is available the update window appears with the release notes. Choose **Install Update** and Purge downloads it, verifies its signature, installs it, and relaunches. You don't need to visit the release page or drag anything.
 
-Purge does not check on its own. Updates only happen when you ask for them, and nothing is contacted in the background.
+Nothing is ever installed without your confirmation. You can also check whenever you like from the **About** screen, and if you'd rather Purge didn't check on its own, turn off **Check for updates automatically** in **Settings → Updates**.
 
 Updates are delivered through [Sparkle](https://sparkle-project.org), the standard update framework for Mac apps outside the App Store. Each update is signed with a key that lives only on the developer's machine, and Purge refuses any download that doesn't carry a matching signature.
 

--- a/purge/Info.plist
+++ b/purge/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>SUEnableAutomaticChecks</key>
-	<false/>
+	<true/>
 	<key>SUFeedURL</key>
 	<string>https://raw.githubusercontent.com/jithin-sabu/purge-app/main/appcast.xml</string>
 	<key>SUPublicEDKey</key>

--- a/purge/Services/PurgeUpdater.swift
+++ b/purge/Services/PurgeUpdater.swift
@@ -2,15 +2,22 @@
 //  PurgeUpdater.swift
 //  purge
 //
-//  Wraps Sparkle for user-initiated "Check for updates" checks.
+//  Wraps Sparkle for scheduled background checks and user-initiated
+//  "Check for updates" checks.
 //
 
 import AppKit
+import Combine
 import Sparkle
 
 @MainActor
-final class PurgeUpdater: NSObject, SPUUpdaterDelegate {
+final class PurgeUpdater: NSObject, ObservableObject, SPUUpdaterDelegate {
     private var controller: SPUStandardUpdaterController!
+
+    /// Mirrors Sparkle's own setting so SwiftUI can observe it. Sparkle persists the real
+    /// value in user defaults under `SUEnableAutomaticChecks`, which takes precedence over
+    /// the Info.plist default.
+    @Published private(set) var automaticallyChecksForUpdates = false
 
     override init() {
         super.init()
@@ -19,6 +26,12 @@ final class PurgeUpdater: NSObject, SPUUpdaterDelegate {
             updaterDelegate: self,
             userDriverDelegate: nil
         )
+        automaticallyChecksForUpdates = controller.updater.automaticallyChecksForUpdates
+    }
+
+    func setAutomaticallyChecksForUpdates(_ enabled: Bool) {
+        controller.updater.automaticallyChecksForUpdates = enabled
+        automaticallyChecksForUpdates = enabled
     }
 
     func checkForUpdates() {
@@ -27,10 +40,6 @@ final class PurgeUpdater: NSObject, SPUUpdaterDelegate {
     }
 
     // MARK: - SPUUpdaterDelegate
-
-    func updaterShouldPromptForPermissionToCheck(forUpdates updater: SPUUpdater) -> Bool {
-        false
-    }
 
     func updater(_ updater: SPUUpdater, didFinishLoading appcast: SUAppcast) {
         // Optional hook; Sparkle clears the session when the update driver finishes.

--- a/purge/Views/SettingsView.swift
+++ b/purge/Views/SettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @EnvironmentObject private var store: PurgeStore
+    @EnvironmentObject private var updater: PurgeUpdater
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @ObservedObject private var prefs = ScheduledCleaningPreferenceStore.shared
     @ObservedObject private var registrar = ScheduledCleaningRegistrar.shared
@@ -39,6 +40,7 @@ struct SettingsView: View {
                     cleaningScheduleSection
                     devToolsSection
                     excludedAppsSection
+                    updatesSection
                     cleaningHistorySection
                 }
             }
@@ -197,6 +199,55 @@ struct SettingsView: View {
                 }
             }
         }
+    }
+
+    private var updatesSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .center) {
+                    Text("Updates")
+                        .font(.headline)
+
+                    Spacer(minLength: 12)
+
+                    Toggle("Check for updates automatically", isOn: automaticUpdateChecksBinding)
+                        .toggleStyle(.switch)
+                        .tint(AppColors.tagSafeText)
+                }
+
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Updates")
+                        .font(.headline)
+
+                    Toggle("Check for updates automatically", isOn: automaticUpdateChecksBinding)
+                        .toggleStyle(.switch)
+                        .tint(AppColors.tagSafeText)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            settingsSectionCard {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text(updatesSummary)
+                        .settingsCaption()
+                }
+                .padding(16)
+            }
+        }
+    }
+
+    private var updatesSummary: String {
+        """
+        Purge checks once a day and shows the update window when a new version is available. \
+        Nothing is installed without your confirmation, and every download is signature-checked.
+        """
+    }
+
+    private var automaticUpdateChecksBinding: Binding<Bool> {
+        Binding(
+            get: { updater.automaticallyChecksForUpdates },
+            set: { updater.setAutomaticallyChecksForUpdates($0) }
+        )
     }
 
     /// Verification affordance: runs the real scheduled-clean pipeline now (same

--- a/purge/purgeApp.swift
+++ b/purge/purgeApp.swift
@@ -82,6 +82,7 @@ struct PurgeApp: App {
                 .environmentObject(store)
                 .environmentObject(diskStore)
                 .environmentObject(trashStore)
+                .environmentObject(appDelegate.updater)
                 .environment(\.purgeAppDelegate, appDelegate)
                 .onAppear {
                     diskStore.refresh()


### PR DESCRIPTION
Closes #19

What this does

Purge now checks for updates once a day. When a newer version exists, Sparkle's
update window appears on its own with the release notes, and the user chooses
whether to install. Previously updates only happened if you opened **About** and
clicked **Check for Updates**.

Why it wasn't happening

`SUEnableAutomaticChecks` was `false` in `Info.plist`, so Sparkle's scheduler
returned early and never ran a background check.

Changes

- **`Info.plist`** — `SUEnableAutomaticChecks` now defaults to `true`. The existing
  `SUScheduledCheckInterval` (86400) governs the daily cadence.
- **`PurgeUpdater`** — conforms to `ObservableObject` and publishes a mirror of
  Sparkle's `automaticallyChecksForUpdates` so SwiftUI can bind to it.
- **Settings** — new **Updates** section with a "Check for updates automatically"
  switch. Sparkle reads user defaults ahead of `Info.plist`, so the toggle cleanly
  overrides the shipped default.
- **README** — the Updating section said Purge never checks on its own, which is no
  longer true.
- Removed `updaterShouldPromptForPermissionToCheck` — Sparkle skips the delegate
  whenever `SUEnableAutomaticChecks` is present in `Info.plist`, so it was never
  called. Happy to restore it if you'd rather keep the hook.

Nothing installs silently: `SUAutomaticallyUpdate` is deliberately left unset, so
Sparkle shows the window and waits for confirmation.

Screenshots

<img width="1432" height="802" alt="Screenshot 2026-08-08 at 3 06 51 PM" src="https://github.com/user-attachments/assets/a6eab281-d3f1-47e0-9ded-c3df279c2dd0" />

Added UI in Settings >> updates

<img width="739" height="153" alt="Screenshot 2026-08-08 at 3 41 04 PM" src="https://github.com/user-attachments/assets/ee6d8fbc-0d22-4422-9f19-aa9a71ff3f05" />

Testing

- Toggle writes through to Sparkle and persists across relaunch
- Temporarily building as 1.2.9/14, the update window appeared unprompted offering 1.3.1
- With the toggle off, no check runs
- `xcodebuild test … CODE_SIGNING_ALLOWED=NO` → **TEST SUCCEEDED**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic daily update checks.
  * Added an update window with release notes and user-confirmed installation.
  * Added an Updates section in Settings with an option to enable or disable automatic checks.
  * Automatic update checks are enabled by default.
* **Documentation**
  * Updated the README with information about automatic and manual update checks.
  * Manual update checks remain available from the About screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->