### PR TITLE
fix: count duplicate copies from the row's point of view (#29)

### DIFF
--- a/PurgeTests/DuplicateFileDetectorTests.swift
+++ b/PurgeTests/DuplicateFileDetectorTests.swift
@@ -231,7 +231,7 @@ struct DuplicateFileDetectorTests {
     // MARK: - Index bookkeeping
 
     /// After a delete, a group of two that lost a member is no longer a duplicate.
-    /// Leaving the survivor badged "2 copies" would misdescribe the disk.
+    /// Leaving the survivor badged "1 other copy" would misdescribe the disk.
     @Test
     func pruningAGroupBelowTwoCopiesDropsItEntirely() {
         let pair = DuplicateGroup(id: "digest-pair", fileIDs: ["/a", "/b"], sizeBytes: 100)

--- a/purge/Views/LargeFilesView.swift
+++ b/purge/Views/LargeFilesView.swift
@@ -890,6 +890,15 @@ private struct LargeFileRow: View {
 
     private var isSelected: Bool { selection.ids.contains(file.id) }
 
+    /// Copies *other than this row*. The row is itself one of the group's members,
+    /// so a badge carrying the group total reads as "and this many more elsewhere"
+    /// and overstates by one (issue #29). Nil for a group of one, which the index
+    /// never produces but the arithmetic shouldn't assume.
+    private var otherCopyCount: Int? {
+        guard let duplicateCopyCount, duplicateCopyCount > 1 else { return nil }
+        return duplicateCopyCount - 1
+    }
+
     /// Fixed, uniform row height so the macOS List never has to *estimate* a row's
     /// height. Estimated-vs-actual drift is what makes a click scroll the list: the
     /// error accumulates over the off-screen rows above, so a click near the top
@@ -1022,11 +1031,12 @@ private struct LargeFileRow: View {
                         .foregroundStyle(.secondary)
                         .layoutPriority(-1)
 
-                    if let duplicateCopyCount {
-                        AppBadge(text: "\(duplicateCopyCount) copies", tone: .warning)
+                    if let otherCopyCount {
+                        let noun = otherCopyCount == 1 ? "copy" : "copies"
+                        AppBadge(text: "\(otherCopyCount) other \(noun)", tone: .warning)
                             .fixedSize()
-                            .help("\(duplicateCopyCount) files in this scan have identical contents.")
-                            .accessibilityLabel("\(duplicateCopyCount) identical copies found")
+                            .help("\(otherCopyCount + 1) files in this scan have identical contents, including this one.")
+                            .accessibilityLabel("\(otherCopyCount) other identical \(noun) found")
                     }
                 }
                 .font(.subheadline)


### PR DESCRIPTION
## What does this change?

The duplicate badge in Large Files showed the size of the whole duplicate group, so a pair of identical files rendered `2 copies` on **each** of the two rows. In the All list every row is a single file, so a count hanging off it reads as "…and that many more elsewhere" — the badge overstated by one.

It now counts the *other* copies: `1 other copy`, `3 other copies`.

| | Badge | Tooltip |
|---|---|---|
| Before | `2 copies` | 2 files in this scan have identical contents. |
| After | `1 other copy` | 2 files in this scan have identical contents, including this one. |

Why this phrasing rather than `1 of 2` / `2 of 2`: duplicates are byte-identical, so they share a size, so under the default sort (largest first) they land next to each other. Ordinals would put two adjacent rows on screen labelled "1 of 2" and "2 of 2" with nothing to justify which was which — and an ordinal in a delete UI reads as a rank, i.e. "keep #1". Purge deliberately doesn't nominate an original (#17). `1 other copy` is true of every member of a group simultaneously and implies no ordering. The group total moves to the tooltip, where there's room to state it.

Unchanged on purpose: the Duplicates card header (`3 identical copies · 4 GB each`) and the delete-confirmation text still use the full count — there the number describes a container whose copies are visibly inside it.

## Related issue

Fixes #29

## Screenshots

<img width="712" height="69" alt="image" src="https://github.com/user-attachments/assets/b6953ecb-0e0e-41f9-986d-34d6b2e1e337" />

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I built and ran the app locally
- [x] I ran the test suite (`xcodebuild ... test`) and it passes
- [x] This PR is focused on a single fix/feature


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated large-file duplicate badges to show the number of additional identical copies.
  - Hidden duplicate badges when no additional copy exists.
  - Updated accessibility and help text to reflect the corrected counts.
- **Tests**
  - Clarified coverage for duplicate groups reduced to a single surviving file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->