### PR TITLE
feat: find build junk for 17 more languages and tools (#33)

### DIFF
--- a/PurgeTests/ElixirProjectArtifactTests.swift
+++ b/PurgeTests/ElixirProjectArtifactTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Testing
+@testable import Purge
+
+/// Elixir/Erlang projects expose two removable folders: `_build` (compiler output)
+/// and `deps` (fetched dependency sources). `_build` is allowed by name like every
+/// other build folder; `deps` is a plain English word, so it is only ever allowed
+/// when a `mix.exs` sits directly beside it.
+private struct MixFixture {
+    let root: URL
+
+    init(withMixExs: Bool, withMixLock: Bool = false) throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("purge-elixir-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        if withMixExs {
+            try Data().write(to: root.appendingPathComponent("mix.exs"))
+        }
+        if withMixLock {
+            try Data().write(to: root.appendingPathComponent("mix.lock"))
+        }
+    }
+
+    var buildDir: URL { root.appendingPathComponent("_build", isDirectory: true) }
+    var depsDir: URL { root.appendingPathComponent("deps", isDirectory: true) }
+
+    func cleanUp() {
+        try? FileManager.default.removeItem(at: root)
+    }
+}
+
+@Suite("Elixir artifact safety")
+struct ElixirArtifactSafetyTests {
+
+    @Test("_build is allowed when a mix.exs sits beside it")
+    func buildFolderAllowed() throws {
+        let fixture = try MixFixture(withMixExs: true)
+        defer { fixture.cleanUp() }
+        #expect(
+            DeletionSafetyPolicy.isWhitelistedProjectArtifactPath(
+                fixture.buildDir,
+                home: fixture.root.deletingLastPathComponent().path
+            )
+        )
+    }
+
+    @Test("_build with no mix.exs beside it is not allowed")
+    func buildFolderWithoutMarkerRejected() throws {
+        let fixture = try MixFixture(withMixExs: false)
+        defer { fixture.cleanUp() }
+        #expect(
+            !DeletionSafetyPolicy.isWhitelistedProjectArtifactPath(
+                fixture.buildDir,
+                home: fixture.root.deletingLastPathComponent().path
+            )
+        )
+    }
+
+    @Test("deps beside a mix.exs is allowed")
+    func depsWithMixExsAllowed() throws {
+        let fixture = try MixFixture(withMixExs: true)
+        defer { fixture.cleanUp() }
+        #expect(
+            DeletionSafetyPolicy.isWhitelistedProjectArtifactPath(
+                fixture.depsDir,
+                home: fixture.root.deletingLastPathComponent().path
+            )
+        )
+    }
+
+    @Test("deps without a mix.exs is not allowed")
+    func depsWithoutMixExsRejected() throws {
+        let fixture = try MixFixture(withMixExs: false)
+        defer { fixture.cleanUp() }
+        #expect(
+            !DeletionSafetyPolicy.isWhitelistedProjectArtifactPath(
+                fixture.depsDir,
+                home: fixture.root.deletingLastPathComponent().path
+            )
+        )
+        // Not `== .blockedNotWhitelisted`: the temp fixture lives under /var, which is
+        // already a never-delete prefix. What matters here is only that it is not allowed.
+        #expect(DeletionSafetyPolicy.evaluate(fixture.depsDir) != .allow)
+    }
+
+    @Test("deps outside the home directory is not allowed")
+    func depsOutsideHomeRejected() throws {
+        let fixture = try MixFixture(withMixExs: true)
+        defer { fixture.cleanUp() }
+        #expect(
+            !DeletionSafetyPolicy.isWhitelistedProjectArtifactPath(
+                fixture.depsDir,
+                home: "/some/other/home"
+            )
+        )
+    }
+
+    /// Both folder-name rules must lose to the never-delete protections, otherwise a
+    /// project checked out inside Pictures or Music would expose that folder.
+    @Test(arguments: ["Pictures", "Music", "Movies", "Library/Mail"])
+    func neverDeletePrefixesBeatFolderNameRules(protectedComponent: String) {
+        let base = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(protectedComponent, isDirectory: true)
+            .appendingPathComponent("my_app", isDirectory: true)
+        #expect(DeletionSafetyPolicy.evaluate(base.appendingPathComponent("_build")) == .blockedNeverDelete)
+        #expect(DeletionSafetyPolicy.evaluate(base.appendingPathComponent("deps")) == .blockedNeverDelete)
+    }
+}
+
+@Suite("Elixir reinstall safety")
+struct ElixirReinstallSafetyTests {
+
+    @Test("_build only needs mix.exs, since it rebuilds from local source")
+    func buildNeedsOnlyMixExs() throws {
+        let fixture = try MixFixture(withMixExs: true)
+        defer { fixture.cleanUp() }
+        #expect(
+            ReinstallSafetyEvaluator.evaluate(artifactKind: .elixirBuild, artifactURL: fixture.buildDir)
+                == .reinstallable
+        )
+    }
+
+    @Test("_build without mix.exs is not treated as reinstallable")
+    func buildWithoutMixExs() throws {
+        let fixture = try MixFixture(withMixExs: false)
+        defer { fixture.cleanUp() }
+        #expect(
+            ReinstallSafetyEvaluator.evaluate(artifactKind: .elixirBuild, artifactURL: fixture.buildDir)
+                == .missingLockfile
+        )
+    }
+
+    @Test("deps needs mix.lock so the same versions come back")
+    func depsNeedsLockfile() throws {
+        let locked = try MixFixture(withMixExs: true, withMixLock: true)
+        defer { locked.cleanUp() }
+        #expect(
+            ReinstallSafetyEvaluator.evaluate(artifactKind: .elixirDeps, artifactURL: locked.depsDir)
+                == .reinstallable
+        )
+
+        let unlocked = try MixFixture(withMixExs: true, withMixLock: false)
+        defer { unlocked.cleanUp() }
+        #expect(
+            ReinstallSafetyEvaluator.evaluate(artifactKind: .elixirDeps, artifactURL: unlocked.depsDir)
+                == .missingLockfile
+        )
+    }
+
+    @Test("folder-name fallback routes _build and deps to the Elixir rules")
+    func folderNameFallback() throws {
+        let fixture = try MixFixture(withMixExs: true, withMixLock: true)
+        defer { fixture.cleanUp() }
+        #expect(ReinstallSafetyEvaluator.evaluateByFolderNameDeleting(path: fixture.buildDir) == .reinstallable)
+        #expect(ReinstallSafetyEvaluator.evaluateByFolderNameDeleting(path: fixture.depsDir) == .reinstallable)
+    }
+}
+
+@Suite("Elixir explanations")
+struct ElixirExplanationTests {
+    @Test(arguments: [DeletableArtifactKind.elixirBuild, .elixirDeps])
+    func explanationKeyResolves(kind: DeletableArtifactKind) {
+        let record = ExplanationDatabase.matchBundledDatabase(folderName: kind.explanationKey)
+        #expect(record != nil, "no explanations.json entry for \(kind.explanationKey)")
+    }
+}

--- a/PurgeTests/ProjectArtifactCatalogTests.swift
+++ b/PurgeTests/ProjectArtifactCatalogTests.swift
@@ -1,0 +1,451 @@
+import Foundation
+import Testing
+@testable import Purge
+
+/// Builds a throwaway project root so anchoring can be tested against real files.
+private struct ProjectFixture {
+    let root: URL
+
+    init(files: [String] = [], folders: [String] = []) throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("purge-catalog-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        for file in files {
+            let url = root.appendingPathComponent(file)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            try Data().write(to: url)
+        }
+        for folder in folders {
+            try FileManager.default.createDirectory(
+                at: root.appendingPathComponent(folder, isDirectory: true),
+                withIntermediateDirectories: true
+            )
+        }
+    }
+
+    func url(_ relative: String) -> URL { root.appendingPathComponent(relative, isDirectory: true) }
+
+    /// Anchoring is checked against a home the fixture actually sits under, since the
+    /// real home would require writing into the user's own directories.
+    var containingHome: String { root.deletingLastPathComponent().path }
+
+    func cleanUp() { try? FileManager.default.removeItem(at: root) }
+}
+
+@Suite("Catalog integrity")
+struct CatalogIntegrityTests {
+
+    @Test("every rule's kind has an explanations.json entry")
+    func everyKindHasAnExplanation() {
+        for rule in ProjectArtifactCatalog.rules {
+            let record = ExplanationDatabase.matchBundledDatabase(folderName: rule.kind.explanationKey)
+            #expect(record != nil, "missing explanation for \(rule.kind.explanationKey)")
+        }
+    }
+
+    @Test("every rule's kind has a row tag distinct from its raw value fallback")
+    func everyKindHasMetadata() {
+        for kind in DeletableArtifactKind.allCases {
+            #expect(!kind.rowTag.isEmpty)
+            #expect(!kind.explanationKey.isEmpty)
+        }
+    }
+
+    /// A rule with no marker of any sort could match on folder name alone, which is
+    /// precisely what `isWhitelistedProjectArtifactPath` exists to prevent.
+    @Test("no rule can fire without some evidence of a real project")
+    func everyRuleIsAnchored() {
+        for rule in ProjectArtifactCatalog.rules {
+            #expect(
+                !rule.rootMarkers.isEmpty || !rule.rootMarkerExtensions.isEmpty,
+                "\(rule.kind.rawValue) has no anchor and would match on name alone"
+            )
+        }
+    }
+
+    @Test("Unity and Unreal artifacts are Check First, never Safe to Clean")
+    func gameEngineArtifactsAreCheckFirst() {
+        let engineTypes: Set<ProjectType> = [.unity, .unreal]
+        let engineRules = ProjectArtifactCatalog.rules.filter { engineTypes.contains($0.projectType) }
+        #expect(!engineRules.isEmpty)
+        for rule in engineRules {
+            #expect(rule.level == .medium, "\(rule.kind.rawValue) must not be auto-cleanable")
+        }
+    }
+
+    @Test("Check First artifacts produce Check First safety info")
+    func checkFirstLevelReachesSafetyInfo() {
+        let info = SafetyInfo.forStaleProjectArtifact(
+            kind: .unityLibrary,
+            path: URL(fileURLWithPath: "/tmp/does-not-exist/Library"),
+            reinstallCommand: nil,
+            level: .medium
+        )
+        #expect(info.level == .medium)
+    }
+}
+
+@Suite("Generic folder names stay blocked without a project above them")
+struct GenericFolderNameTests {
+
+    /// The whole point of anchoring. These names are common enough that allowing them
+    /// on name alone would expose ordinary user folders.
+    @Test(arguments: ["bin", "obj", "vendor", "Library", "Temp", "deps", "build", "target"])
+    func bareFolderIsNotAllowed(name: String) throws {
+        let fixture = try ProjectFixture(folders: [name])
+        defer { fixture.cleanUp() }
+        #expect(
+            !DeletionSafetyPolicy.isWhitelistedProjectArtifactPath(
+                fixture.url(name), home: fixture.containingHome
+            ),
+            "\(name) was allowed with no project marker beside it"
+        )
+    }
+
+    @Test("the home Library folder is never deletable")
+    func homeLibraryIsProtected() {
+        let library = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library", isDirectory: true)
+        #expect(DeletionSafetyPolicy.evaluate(library) == .blockedNeverDelete)
+    }
+
+    @Test("caches inside the home Library folder are still reachable")
+    func homeLibraryChildrenStillAllowed() {
+        let caches = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Caches", isDirectory: true)
+        #expect(DeletionSafetyPolicy.evaluate(caches) == .allow)
+    }
+}
+
+@Suite("Anchored artifacts are allowed when the project is real")
+struct AnchoredArtifactTests {
+
+    @Test(arguments: [
+        ("composer.json", "vendor"),
+        ("mix.exs", "deps"),
+        ("mix.exs", "_build"),
+        ("Package.swift", ".build"),
+        ("pom.xml", "target"),
+        ("build.sbt", "target"),
+        ("stack.yaml", ".stack-work"),
+        ("build.zig", "zig-out"),
+        ("dune-project", "_build"),
+        ("CMakeLists.txt", "build"),
+        ("project.godot", ".godot"),
+        ("ProjectSettings/ProjectVersion.txt", "Library"),
+    ])
+    func markerBesideFolderAllowsIt(marker: String, folder: String) throws {
+        let fixture = try ProjectFixture(files: [marker], folders: [folder])
+        defer { fixture.cleanUp() }
+        #expect(
+            DeletionSafetyPolicy.isWhitelistedProjectArtifactPath(
+                fixture.url(folder), home: fixture.containingHome
+            ),
+            "\(folder) was not allowed next to \(marker)"
+        )
+    }
+
+    @Test(arguments: [
+        ("App.csproj", "bin"),
+        ("App.csproj", "obj"),
+        ("main.tf", ".terraform"),
+        ("Game.uproject", "Intermediate"),
+        ("project.cabal", "dist-newstyle"),
+    ])
+    func extensionMarkerAllowsIt(marker: String, folder: String) throws {
+        let fixture = try ProjectFixture(files: [marker], folders: [folder])
+        defer { fixture.cleanUp() }
+        #expect(
+            DeletionSafetyPolicy.isWhitelistedProjectArtifactPath(
+                fixture.url(folder), home: fixture.containingHome
+            ),
+            "\(folder) was not allowed next to \(marker)"
+        )
+    }
+
+    @Test("a nested artifact anchors on the project root, not its parent folder")
+    func nestedArtifactAnchorsOnRoot() throws {
+        let fixture = try ProjectFixture(files: ["ios/Podfile"], folders: ["ios/Pods"])
+        defer { fixture.cleanUp() }
+        #expect(
+            DeletionSafetyPolicy.isWhitelistedProjectArtifactPath(
+                fixture.url("ios/Pods"), home: fixture.containingHome
+            )
+        )
+    }
+
+    @Test("the wrong marker does not unlock an unrelated folder")
+    func wrongMarkerIsRejected() throws {
+        // A Go project keeps `vendor` under version control, so a `go.mod` must never
+        // make it deletable. Only Composer's marker does that.
+        let fixture = try ProjectFixture(files: ["go.mod"], folders: ["vendor"])
+        defer { fixture.cleanUp() }
+        #expect(
+            !DeletionSafetyPolicy.isWhitelistedProjectArtifactPath(
+                fixture.url("vendor"), home: fixture.containingHome
+            )
+        )
+    }
+
+    @Test("never-delete protections still beat a real project marker")
+    func neverDeleteBeatsAnchoring() {
+        // Simulated rather than written to disk: these are the user's real folders.
+        let base = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Pictures/my_game", isDirectory: true)
+        #expect(DeletionSafetyPolicy.evaluate(base.appendingPathComponent("Library")) == .blockedNeverDelete)
+        #expect(DeletionSafetyPolicy.evaluate(base.appendingPathComponent("vendor")) == .blockedNeverDelete)
+    }
+}
+
+@Suite("Reinstall safety reads from the catalog")
+struct CatalogReinstallTests {
+
+    @Test("Composer vendor needs composer.lock")
+    func composerNeedsLock() throws {
+        let locked = try ProjectFixture(files: ["composer.json", "composer.lock"], folders: ["vendor"])
+        defer { locked.cleanUp() }
+        #expect(
+            ReinstallSafetyEvaluator.evaluate(artifactKind: .composerVendor, artifactURL: locked.url("vendor"))
+                == .reinstallable
+        )
+
+        let unlocked = try ProjectFixture(files: ["composer.json"], folders: ["vendor"])
+        defer { unlocked.cleanUp() }
+        #expect(
+            ReinstallSafetyEvaluator.evaluate(artifactKind: .composerVendor, artifactURL: unlocked.url("vendor"))
+                == .missingLockfile
+        )
+    }
+
+    @Test("node_modules keeps its existing lockfile behaviour")
+    func nodeModulesUnchanged() throws {
+        let locked = try ProjectFixture(files: ["package.json", "package-lock.json"], folders: ["node_modules"])
+        defer { locked.cleanUp() }
+        #expect(
+            ReinstallSafetyEvaluator.evaluate(artifactKind: .nodeModules, artifactURL: locked.url("node_modules"))
+                == .reinstallable
+        )
+
+        let unlocked = try ProjectFixture(files: ["package.json"], folders: ["node_modules"])
+        defer { unlocked.cleanUp() }
+        #expect(
+            ReinstallSafetyEvaluator.evaluate(artifactKind: .nodeModules, artifactURL: unlocked.url("node_modules"))
+                == .missingLockfile
+        )
+    }
+
+    @Test("artifacts that regenerate from local source need no lockfile")
+    func localRebuildNeedsNoLock() throws {
+        let fixture = try ProjectFixture(files: ["Cargo.toml"], folders: ["target"])
+        defer { fixture.cleanUp() }
+        #expect(
+            ReinstallSafetyEvaluator.evaluate(artifactKind: .target, artifactURL: fixture.url("target"))
+                == .reinstallable
+        )
+    }
+}
+
+// MARK: - Review follow-ups
+
+@Suite("Terraform state is never treated as disposable")
+struct TerraformStateTests {
+
+    @Test("a .terraform folder holding state is refused outright")
+    func stateFolderIsRefused() throws {
+        for stateFile in ["terraform.tfstate", "terraform.tfstate.backup", "environment"] {
+            let fixture = try ProjectFixture(
+                files: ["main.tf", ".terraform/\(stateFile)"], folders: [".terraform"]
+            )
+            defer { fixture.cleanUp() }
+            #expect(
+                !DeletionSafetyPolicy.isWhitelistedProjectArtifactPath(
+                    fixture.url(".terraform"), home: fixture.containingHome
+                ),
+                ".terraform containing \(stateFile) was offered for deletion"
+            )
+        }
+    }
+
+    @Test("a .terraform folder with only providers is still offered")
+    func pluginOnlyFolderIsAllowed() throws {
+        let fixture = try ProjectFixture(
+            files: ["main.tf"], folders: [".terraform/providers"]
+        )
+        defer { fixture.cleanUp() }
+        #expect(
+            DeletionSafetyPolicy.isWhitelistedProjectArtifactPath(
+                fixture.url(".terraform"), home: fixture.containingHome
+            )
+        )
+    }
+
+    @Test("Terraform is Check First, not Safe to Clean")
+    func terraformIsCheckFirst() {
+        let rules = ProjectArtifactCatalog.rules(forKind: .terraformPlugins)
+        #expect(!rules.isEmpty)
+        for rule in rules {
+            #expect(rule.level == .medium)
+        }
+    }
+}
+
+@Suite("Toolchain install directories are not offered as caches")
+struct ToolchainInstallTests {
+
+    /// `deno upgrade` and `deno install` put the binary and script shims under
+    /// `~/.deno/bin`, so the install root must never be on the allowlist.
+    @Test(arguments: [".deno", ".deno/bin", ".cargo/bin", ".bun/bin"])
+    func installRootIsNotDeletable(relative: String) {
+        let url = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(relative, isDirectory: true)
+        #expect(DeletionSafetyPolicy.evaluate(url) != .allow, "\(relative) was allowed")
+    }
+
+    @Test("the actual Deno and Bun caches are still reachable")
+    func realCachesStillAllowed() {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        #expect(DeletionSafetyPolicy.evaluate(home.appendingPathComponent("Library/Caches/deno")) == .allow)
+        #expect(DeletionSafetyPolicy.evaluate(home.appendingPathComponent(".bun/install/cache")) == .allow)
+    }
+}
+
+@Suite("Shared folder names route to every matching ecosystem")
+struct SharedFolderNameRoutingTests {
+
+    /// `target` belongs to Rust, Maven and sbt; `_build` to both Elixir and Dune.
+    /// Matching only the first rule in the catalog reports a rebuildable project as
+    /// missing its lockfile.
+    @Test(arguments: [
+        ("Cargo.toml", "target"),
+        ("pom.xml", "target"),
+        ("build.sbt", "target"),
+        ("mix.exs", "_build"),
+        ("dune-project", "_build"),
+    ])
+    func anyMatchingEcosystemCounts(marker: String, folder: String) throws {
+        let fixture = try ProjectFixture(files: [marker], folders: [folder])
+        defer { fixture.cleanUp() }
+        #expect(
+            ReinstallSafetyEvaluator.evaluateByFolderNameDeleting(path: fixture.url(folder))
+                == .reinstallable,
+            "\(folder) beside \(marker) was not recognised as rebuildable"
+        )
+    }
+
+    @Test("a shared folder name with no matching project still reports missing evidence")
+    func noMarkerMeansNoEvidence() throws {
+        let fixture = try ProjectFixture(folders: ["target"])
+        defer { fixture.cleanUp() }
+        #expect(
+            ReinstallSafetyEvaluator.evaluateByFolderNameDeleting(path: fixture.url("target"))
+                == .missingLockfile
+        )
+    }
+}
+
+/// Rooted under the real home directory, because `collectArtifacts` puts every path
+/// through `DeletionSafetyPolicy`, which correctly refuses anything under `/var` where
+/// the temporary directory lives. Removed again in `cleanUp`.
+private struct HomeScopedFixture {
+    static let container = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".purge-test-fixtures", isDirectory: true)
+
+    let root: URL
+
+    init(files: [String] = [], folders: [String] = []) throws {
+        root = Self.container.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        for file in files {
+            let url = root.appendingPathComponent(file)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            try Data().write(to: url)
+        }
+        for folder in folders {
+            try FileManager.default.createDirectory(
+                at: root.appendingPathComponent(folder, isDirectory: true),
+                withIntermediateDirectories: true
+            )
+        }
+    }
+
+    func url(_ relative: String) -> URL { root.appendingPathComponent(relative, isDirectory: true) }
+
+    func cleanUp() {
+        try? FileManager.default.removeItem(at: root)
+        // Tests using this fixture run in parallel and share the container, so it can
+        // only be removed when nothing is left in it — never recursively.
+        let remaining = (try? FileManager.default.contentsOfDirectory(at: Self.container, includingPropertiesForKeys: nil)) ?? []
+        if remaining.isEmpty { try? FileManager.default.removeItem(at: Self.container) }
+    }
+}
+
+@Suite("Artifacts are actually collected end to end")
+struct ArtifactCollectionTests {
+
+    private func collect(_ fixture: HomeScopedFixture, _ types: [ProjectType]) -> Set<DeletableArtifactKind> {
+        Set(
+            DevScanner.collectArtifacts(projectRoot: fixture.root, types: types)
+                .map(\.kind)
+        )
+    }
+
+    @Test("a Zig project yields its cache and output folders")
+    func zigProject() throws {
+        let fixture = try HomeScopedFixture(files: ["build.zig"], folders: [".zig-cache", "zig-out"])
+        defer { fixture.cleanUp() }
+        let kinds = collect(fixture, [.zig])
+        #expect(kinds.contains(.zigCache))
+        #expect(kinds.contains(.zigOut))
+    }
+
+    @Test("a Composer project yields its vendor folder")
+    func composerProject() throws {
+        let fixture = try HomeScopedFixture(files: ["composer.json", "composer.lock"], folders: ["vendor"])
+        defer { fixture.cleanUp() }
+        #expect(collect(fixture, [.composer]).contains(.composerVendor))
+    }
+
+    @Test("a rule whose marker is absent contributes nothing")
+    func unmatchedRuleContributesNothing() throws {
+        // Python markers present, but no tox.ini, so `.tox` must not be offered.
+        let fixture = try HomeScopedFixture(files: ["requirements.txt"], folders: [".tox", "venv"])
+        defer { fixture.cleanUp() }
+        let kinds = collect(fixture, [.python])
+        #expect(kinds.contains(.venv))
+        #expect(!kinds.contains(.toxEnvironments))
+    }
+
+    @Test("a Terraform workspace holding state contributes nothing")
+    func terraformStateIsNotCollected() throws {
+        let fixture = try HomeScopedFixture(
+            files: ["main.tf", ".terraform/terraform.tfstate"], folders: [".terraform"]
+        )
+        defer { fixture.cleanUp() }
+        #expect(collect(fixture, [.terraform]).isEmpty)
+    }
+}
+
+@Suite("Project type labels are distinguishable")
+struct ProjectTypeLabelTests {
+    @Test("no two project types share a display name")
+    func displayNamesAreUnique() {
+        var seen: [String: ProjectType] = [:]
+        for type in ProjectType.allCases {
+            if let clash = seen[type.displayName] {
+                Issue.record("\(type) and \(clash) both display as \(type.displayName)")
+            }
+            seen[type.displayName] = type
+        }
+    }
+
+    @Test("artifact kind raw values stay machine-shaped")
+    func rawValuesHaveNoSpaces() {
+        for kind in DeletableArtifactKind.allCases {
+            #expect(!kind.rawValue.contains(" "), "\(kind) raw value has a space: \(kind.rawValue)")
+        }
+    }
+}

--- a/purge/Models/CleanupExplanation.swift
+++ b/purge/Models/CleanupExplanation.swift
@@ -43,11 +43,15 @@ extension SafetyInfo {
         )
     }
 
-    /// Safety for project artifacts shown after staleness filtering — always Safe to Clean unless user-overridden.
+    /// Safety for project artifacts shown after staleness filtering. Safe to Clean by
+    /// default, unless the user has overridden this exact path, or the artifact's rule
+    /// declares a stricter tier (Unity and Unreal are Check First because rebuilding
+    /// them costs real time even though it is automatic).
     nonisolated static func forStaleProjectArtifact(
         kind: DeletableArtifactKind,
         path: URL,
-        reinstallCommand: String? = nil
+        reinstallCommand: String? = nil,
+        level: SafetyLevel = .safe
     ) -> SafetyInfo {
         let base = fromExplanationDatabase(
             key: kind.explanationKey,
@@ -57,7 +61,7 @@ extension SafetyInfo {
         )
         if UserOverridesStore.read(path: path) != nil { return base }
         return SafetyInfo(
-            level: .safe,
+            level: level,
             headline: base.headline,
             explanation: base.explanation,
             recoverySteps: base.recoverySteps,

--- a/purge/Models/ProjectArtifactCatalog.swift
+++ b/purge/Models/ProjectArtifactCatalog.swift
@@ -1,0 +1,359 @@
+import Foundation
+
+/// How a removed artifact is brought back.
+nonisolated enum ReinstallInstruction: Hashable, Sendable {
+    /// Shell command run from the project root. `{root}` is substituted with the path.
+    case command(String)
+    /// Plain-English steps, for ecosystems with no single reliable command.
+    case guidance(String)
+    /// npm/pnpm/yarn, chosen by which lockfile is present.
+    case nodePackageManager
+    /// `pod install`, run from wherever the Podfile actually lives.
+    case cocoaPods
+    case none
+}
+
+/// One removable folder belonging to one kind of project.
+///
+/// This table is the single source of truth for project artifacts: what identifies
+/// the project, which folder is removable, how it comes back, and how risky removing
+/// it is. Adding an ecosystem means adding rows here and an `explanations.json` entry,
+/// with no new switch statements to keep in sync.
+///
+/// Safety note: a rule here only ever *proposes* a path. Every proposal is still put
+/// through `DeletionSafetyPolicy.isOfferedForCleanup`, so a rule cannot widen what the
+/// app is allowed to delete. It can only narrow it.
+nonisolated struct ProjectArtifactRule: Hashable, Sendable {
+    let kind: DeletableArtifactKind
+    let projectType: ProjectType
+
+    /// Folder to remove, relative to the project root. May contain a subdirectory
+    /// (`ios/Pods`, `project/target`).
+    let folder: String
+
+    /// Any one of these, relative to the project root, must exist for the rule to fire.
+    let rootMarkers: [String]
+
+    /// File extensions that identify the project when no fixed filename does
+    /// (`.csproj`, `.cabal`, `.tf`, `.uproject`). Checked by listing the root.
+    let rootMarkerExtensions: [String]
+
+    /// Any one of these must exist for a clean rebuild, resolved relative to the
+    /// artifact's own parent directory (`..` is allowed and standardized). Empty
+    /// means `rebuildMarkers` alone is enough.
+    let lockfiles: [String]
+
+    /// Evidence that a rebuild is possible at all, resolved like `lockfiles`.
+    /// Empty means no evidence is required.
+    let rebuildMarkers: [String]
+
+    /// Filenames that, if found *inside* the artifact folder, disqualify it entirely.
+    /// This is for folders that are usually disposable but sometimes hold real state.
+    let refuseWhenPresent: [String]
+
+    let reinstall: ReinstallInstruction
+
+    /// `.safe` participates in one-click and scheduled cleaning. `.medium` ("Check
+    /// First") is shown but never auto-selected, which is the right tier for anything
+    /// that technically rebuilds itself but costs the user real time when it does.
+    let level: SafetyLevel
+
+    init(
+        kind: DeletableArtifactKind,
+        projectType: ProjectType,
+        folder: String,
+        rootMarkers: [String],
+        rootMarkerExtensions: [String] = [],
+        lockfiles: [String] = [],
+        rebuildMarkers: [String] = [],
+        refuseWhenPresent: [String] = [],
+        reinstall: ReinstallInstruction,
+        level: SafetyLevel = .safe
+    ) {
+        self.kind = kind
+        self.projectType = projectType
+        self.folder = folder
+        self.rootMarkers = rootMarkers
+        self.rootMarkerExtensions = rootMarkerExtensions
+        self.lockfiles = lockfiles
+        self.rebuildMarkers = rebuildMarkers
+        self.refuseWhenPresent = refuseWhenPresent
+        self.reinstall = reinstall
+        self.level = level
+    }
+}
+
+extension ProjectArtifactRule {
+    /// Whether `root` really is a project this rule applies to.
+    nonisolated func matchesRoot(_ root: URL) -> Bool {
+        let fm = FileManager.default
+        if rootMarkers.contains(where: { fm.fileExists(atPath: root.appendingPathComponent($0).path) }) {
+            return true
+        }
+        guard !rootMarkerExtensions.isEmpty else { return false }
+        guard let children = try? fm.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
+        ) else {
+            return false
+        }
+        let wanted = Set(rootMarkerExtensions.map { $0.lowercased() })
+        return children.contains { wanted.contains($0.pathExtension.lowercased()) }
+    }
+
+    /// Whether this particular folder holds something that must not be thrown away,
+    /// even though folders of this kind normally can be.
+    nonisolated func refusesArtifact(at url: URL) -> Bool {
+        guard !refuseWhenPresent.isEmpty else { return false }
+        let fm = FileManager.default
+        return refuseWhenPresent.contains { fm.fileExists(atPath: url.appendingPathComponent($0).path) }
+    }
+}
+
+nonisolated enum ProjectArtifactCatalog {
+
+    // MARK: - Rules
+
+    /// Ordering is cosmetic only; lookups are by kind or project type.
+    nonisolated static let rules: [ProjectArtifactRule] = [
+
+        // MARK: JavaScript / TypeScript
+
+        .init(
+            kind: .nodeModules, projectType: .node, folder: "node_modules",
+            rootMarkers: ["package.json"],
+            lockfiles: ["package-lock.json", "npm-shrinkwrap.json", "yarn.lock", "pnpm-lock.yaml"],
+            rebuildMarkers: ["package.json"],
+            reinstall: .nodePackageManager
+        ),
+        // Framework output folders. Purge's safety list already permitted these; until
+        // now nothing ever looked for them, so they were allowed and invisible.
+        .init(kind: .nextBuild, projectType: .node, folder: ".next",
+              rootMarkers: ["package.json"], rebuildMarkers: ["package.json"],
+              reinstall: .nodePackageManager),
+        .init(kind: .nuxtBuild, projectType: .node, folder: ".nuxt",
+              rootMarkers: ["nuxt.config.ts", "nuxt.config.js", "nuxt.config.mjs", "nuxt.config.cjs"], rebuildMarkers: ["package.json"],
+              reinstall: .nodePackageManager),
+        // `.output` is the loosest folder name in the table, so it is anchored on a Nuxt
+        // config rather than on `package.json` like its siblings.
+        .init(kind: .nuxtOutput, projectType: .node, folder: ".output",
+              rootMarkers: ["nuxt.config.ts", "nuxt.config.js", "nuxt.config.mjs", "nuxt.config.cjs"], rebuildMarkers: ["package.json"],
+              reinstall: .nodePackageManager),
+        .init(kind: .svelteKitBuild, projectType: .node, folder: ".svelte-kit",
+              rootMarkers: ["package.json"], rebuildMarkers: ["package.json"],
+              reinstall: .nodePackageManager),
+        .init(kind: .astroBuild, projectType: .node, folder: ".astro",
+              rootMarkers: ["package.json"], rebuildMarkers: ["package.json"],
+              reinstall: .nodePackageManager),
+        .init(kind: .angularCache, projectType: .node, folder: ".angular",
+              rootMarkers: ["package.json"], rebuildMarkers: ["package.json"],
+              reinstall: .nodePackageManager),
+        .init(kind: .turboCache, projectType: .node, folder: ".turbo",
+              rootMarkers: ["package.json"], rebuildMarkers: ["package.json"],
+              reinstall: .nodePackageManager),
+        .init(kind: .parcelCache, projectType: .node, folder: ".parcel-cache",
+              rootMarkers: ["package.json"], rebuildMarkers: ["package.json"],
+              reinstall: .nodePackageManager),
+        .init(kind: .viteCache, projectType: .node, folder: "node_modules/.vite",
+              rootMarkers: ["package.json"], rebuildMarkers: ["../package.json"],
+              reinstall: .nodePackageManager),
+
+        // MARK: Rust
+
+        .init(kind: .target, projectType: .rust, folder: "target",
+              rootMarkers: ["Cargo.toml"], rebuildMarkers: ["Cargo.toml"],
+              reinstall: .command("cd \"{root}\" && cargo build")),
+
+        // MARK: Python
+
+        .init(kind: .venv, projectType: .python, folder: "venv",
+              rootMarkers: ["requirements.txt", "pyproject.toml"],
+              rebuildMarkers: ["requirements.txt", "pyproject.toml"],
+              reinstall: .guidance("Use your usual steps to recreate the Python environment for this folder.")),
+        .init(kind: .venv, projectType: .python, folder: ".venv",
+              rootMarkers: ["requirements.txt", "pyproject.toml"],
+              rebuildMarkers: ["requirements.txt", "pyproject.toml"],
+              reinstall: .guidance("Use your usual steps to recreate the Python environment for this folder.")),
+        .init(kind: .pytestCache, projectType: .python, folder: ".pytest_cache",
+              rootMarkers: ["requirements.txt", "pyproject.toml"],
+              reinstall: .guidance("Recreated automatically the next time you run your tests.")),
+        .init(kind: .mypyCache, projectType: .python, folder: ".mypy_cache",
+              rootMarkers: ["requirements.txt", "pyproject.toml"],
+              reinstall: .guidance("Recreated automatically the next time you run mypy.")),
+        .init(kind: .ruffCache, projectType: .python, folder: ".ruff_cache",
+              rootMarkers: ["requirements.txt", "pyproject.toml"],
+              reinstall: .guidance("Recreated automatically the next time you run ruff.")),
+        .init(kind: .toxEnvironments, projectType: .python, folder: ".tox",
+              rootMarkers: ["tox.ini"],
+              reinstall: .command("cd \"{root}\" && tox")),
+
+        // MARK: Flutter / Dart
+
+        .init(kind: .dartTool, projectType: .flutter, folder: ".dart_tool",
+              rootMarkers: ["pubspec.yaml"], lockfiles: ["pubspec.lock"],
+              rebuildMarkers: ["pubspec.yaml"],
+              reinstall: .command("cd \"{root}\" && flutter pub get")),
+        .init(kind: .flutterBuild, projectType: .flutter, folder: "build",
+              rootMarkers: ["pubspec.yaml"], lockfiles: ["pubspec.lock"],
+              rebuildMarkers: ["pubspec.yaml"],
+              reinstall: .command("cd \"{root}\" && flutter pub get")),
+
+        // MARK: Android
+
+        .init(kind: .dotGradle, projectType: .androidGradle, folder: ".gradle",
+              rootMarkers: ["build.gradle", "build.gradle.kts", "settings.gradle",
+                            "settings.gradle.kts", "android/build.gradle", "android/build.gradle.kts"],
+              rebuildMarkers: ["build.gradle", "build.gradle.kts", "settings.gradle",
+                               "settings.gradle.kts", "android/build.gradle", "android/build.gradle.kts"],
+              reinstall: .guidance("Run your usual project build so Android or Java tools fetch what they need again.")),
+
+        // MARK: Xcode / CocoaPods
+
+        .init(kind: .pods, projectType: .xcode, folder: "Pods",
+              rootMarkers: ["Podfile"], lockfiles: ["Podfile.lock"],
+              reinstall: .cocoaPods),
+        .init(kind: .pods, projectType: .xcode, folder: "ios/Pods",
+              rootMarkers: ["ios/Podfile"], lockfiles: ["Podfile.lock"],
+              reinstall: .cocoaPods),
+        .init(kind: .swiftPMBuild, projectType: .swiftPackage, folder: ".build",
+              rootMarkers: ["Package.swift"], rebuildMarkers: ["Package.swift"],
+              reinstall: .command("cd \"{root}\" && swift build")),
+
+        // MARK: Elixir / Erlang
+
+        .init(kind: .elixirBuild, projectType: .elixir, folder: "_build",
+              rootMarkers: ["mix.exs"], rebuildMarkers: ["mix.exs"],
+              reinstall: .command("cd \"{root}\" && mix compile")),
+        .init(kind: .elixirDeps, projectType: .elixir, folder: "deps",
+              rootMarkers: ["mix.exs"], lockfiles: ["mix.lock"], rebuildMarkers: ["mix.exs"],
+              reinstall: .command("cd \"{root}\" && mix deps.get")),
+
+        // MARK: JVM
+
+        .init(kind: .mavenTarget, projectType: .maven, folder: "target",
+              rootMarkers: ["pom.xml"], rebuildMarkers: ["pom.xml"],
+              reinstall: .command("cd \"{root}\" && mvn package")),
+        .init(kind: .gradleBuild, projectType: .gradleJVM, folder: "build",
+              rootMarkers: ["build.gradle", "build.gradle.kts"],
+              rebuildMarkers: ["build.gradle", "build.gradle.kts"],
+              reinstall: .command("cd \"{root}\" && ./gradlew build")),
+        .init(kind: .sbtTarget, projectType: .sbt, folder: "target",
+              rootMarkers: ["build.sbt"], rebuildMarkers: ["build.sbt"],
+              reinstall: .command("cd \"{root}\" && sbt compile")),
+        .init(kind: .sbtTarget, projectType: .sbt, folder: "project/target",
+              rootMarkers: ["build.sbt"], rebuildMarkers: ["../build.sbt"],
+              reinstall: .command("cd \"{root}\" && sbt compile")),
+
+        // MARK: .NET
+
+        .init(kind: .dotnetBin, projectType: .dotnet, folder: "bin",
+              rootMarkers: [], rootMarkerExtensions: ["csproj", "fsproj", "vbproj", "sln"], rebuildMarkers: [],
+              reinstall: .command("cd \"{root}\" && dotnet build")),
+        .init(kind: .dotnetObj, projectType: .dotnet, folder: "obj",
+              rootMarkers: [], rootMarkerExtensions: ["csproj", "fsproj", "vbproj", "sln"], rebuildMarkers: [],
+              reinstall: .command("cd \"{root}\" && dotnet build")),
+
+        // MARK: PHP / Ruby
+
+        .init(kind: .composerVendor, projectType: .composer, folder: "vendor",
+              rootMarkers: ["composer.json"], lockfiles: ["composer.lock"],
+              rebuildMarkers: ["composer.json"],
+              reinstall: .command("cd \"{root}\" && composer install")),
+        .init(kind: .bundlerVendor, projectType: .bundler, folder: "vendor/bundle",
+              rootMarkers: ["Gemfile"], lockfiles: ["../Gemfile.lock"],
+              rebuildMarkers: ["../Gemfile"],
+              reinstall: .command("cd \"{root}\" && bundle install")),
+
+        // MARK: Haskell
+
+        .init(kind: .stackWork, projectType: .haskellStack, folder: ".stack-work",
+              rootMarkers: ["stack.yaml"], rebuildMarkers: ["stack.yaml"],
+              reinstall: .command("cd \"{root}\" && stack build")),
+        .init(kind: .cabalDist, projectType: .haskellCabal, folder: "dist-newstyle",
+              rootMarkers: [], rootMarkerExtensions: ["cabal"], rebuildMarkers: [],
+              reinstall: .command("cd \"{root}\" && cabal build")),
+
+        // MARK: Zig / OCaml / native
+
+        .init(kind: .zigCache, projectType: .zig, folder: ".zig-cache",
+              rootMarkers: ["build.zig"], rebuildMarkers: ["build.zig"],
+              reinstall: .command("cd \"{root}\" && zig build")),
+        .init(kind: .zigCache, projectType: .zig, folder: "zig-cache",
+              rootMarkers: ["build.zig"], rebuildMarkers: ["build.zig"],
+              reinstall: .command("cd \"{root}\" && zig build")),
+        .init(kind: .zigOut, projectType: .zig, folder: "zig-out",
+              rootMarkers: ["build.zig"], rebuildMarkers: ["build.zig"],
+              reinstall: .command("cd \"{root}\" && zig build")),
+        .init(kind: .duneBuild, projectType: .ocamlDune, folder: "_build",
+              rootMarkers: ["dune-project"], rebuildMarkers: ["dune-project"],
+              reinstall: .command("cd \"{root}\" && dune build")),
+        .init(kind: .cmakeBuild, projectType: .cmake, folder: "build",
+              rootMarkers: ["CMakeLists.txt"], rebuildMarkers: ["CMakeLists.txt"],
+              reinstall: .guidance("Re-run your usual CMake configure and build steps.")),
+
+        // MARK: Infrastructure / engines
+
+        // `.terraform` is mostly downloaded providers and modules, but it is also where
+        // the backend writes `terraform.tfstate` and the selected workspace. Losing state
+        // can mean losing track of real running infrastructure, so this is Check First,
+        // and any folder actually holding state is refused outright rather than offered.
+        .init(kind: .terraformPlugins, projectType: .terraform, folder: ".terraform",
+              rootMarkers: [], rootMarkerExtensions: ["tf"], rebuildMarkers: [],
+              refuseWhenPresent: ["terraform.tfstate", "terraform.tfstate.backup", "environment"],
+              reinstall: .command("cd \"{root}\" && terraform init"),
+              level: .medium),
+        .init(kind: .godotCache, projectType: .godot, folder: ".godot",
+              rootMarkers: ["project.godot"], rebuildMarkers: ["project.godot"],
+              reinstall: .guidance("Rebuilt automatically the next time you open the project in Godot.")),
+
+        // Unity and Unreal rebuild themselves, but a reimport or shader rebuild can
+        // cost half an hour on a large project and starts the moment the editor next
+        // opens. Deliberately `.medium` so they are never swept up by one-click or
+        // scheduled cleaning; the user has to choose them.
+        .init(kind: .unityLibrary, projectType: .unity, folder: "Library",
+              rootMarkers: ["ProjectSettings/ProjectVersion.txt"],
+              rebuildMarkers: ["ProjectSettings/ProjectVersion.txt"],
+              reinstall: .guidance("Unity reimports the project the next time you open it. On a large project this can take a long time."),
+              level: .medium),
+        .init(kind: .unityTemp, projectType: .unity, folder: "Temp",
+              rootMarkers: ["ProjectSettings/ProjectVersion.txt"],
+              reinstall: .guidance("Recreated automatically the next time you open the project in Unity."),
+              level: .medium),
+        .init(kind: .unrealIntermediate, projectType: .unreal, folder: "Intermediate",
+              rootMarkers: [], rootMarkerExtensions: ["uproject"], rebuildMarkers: [],
+              reinstall: .guidance("Regenerated the next time you build the project in Unreal."),
+              level: .medium),
+        .init(kind: .unrealDerivedData, projectType: .unreal, folder: "DerivedDataCache",
+              rootMarkers: [], rootMarkerExtensions: ["uproject"], rebuildMarkers: [],
+              reinstall: .guidance("Unreal rebuilds this cache on the next build. Expect a long first build, including shader compilation."),
+              level: .medium),
+    ]
+
+    // MARK: - Lookups
+
+    private nonisolated static let rulesByType: [ProjectType: [ProjectArtifactRule]] =
+        Dictionary(grouping: rules, by: \.projectType)
+
+    private nonisolated static let rulesByKind: [DeletableArtifactKind: [ProjectArtifactRule]] =
+        Dictionary(grouping: rules, by: \.kind)
+
+    nonisolated static func rules(for type: ProjectType) -> [ProjectArtifactRule] {
+        rulesByType[type] ?? []
+    }
+
+    nonisolated static func rules(forKind kind: DeletableArtifactKind) -> [ProjectArtifactRule] {
+        rulesByKind[kind] ?? []
+    }
+
+    /// Rules grouped by the final component of their folder, so a path check only
+    /// considers the handful of rules whose folder name could possibly match.
+    nonisolated static let rulesByFolderName: [String: [ProjectArtifactRule]] =
+        Dictionary(grouping: rules) { URL(fileURLWithPath: $0.folder).lastPathComponent }
+
+    /// Folder names any rule can propose, used to skip descending into them while
+    /// walking for project roots.
+    nonisolated static let artifactFolderNames: Set<String> = Set(
+        rules.map { URL(fileURLWithPath: $0.folder).lastPathComponent }
+    )
+}

--- a/purge/Models/ProjectModels.swift
+++ b/purge/Models/ProjectModels.swift
@@ -29,13 +29,30 @@ enum NodePackageManager: String, Hashable, Sendable {
     }
 }
 
-nonisolated enum ProjectType: Hashable, Sendable {
+nonisolated enum ProjectType: String, Hashable, Sendable, CaseIterable {
     case node
     case rust
     case flutter
     case xcode
     case python
     case androidGradle
+    case elixir
+    case swiftPackage
+    case maven
+    case gradleJVM
+    case sbt
+    case dotnet
+    case composer
+    case bundler
+    case haskellStack
+    case haskellCabal
+    case zig
+    case ocamlDune
+    case cmake
+    case terraform
+    case godot
+    case unity
+    case unreal
 
     var displayName: String {
         switch self {
@@ -45,44 +62,129 @@ nonisolated enum ProjectType: Hashable, Sendable {
         case .xcode: return "Xcode"
         case .python: return "Python"
         case .androidGradle: return "Android"
+        case .elixir: return "Elixir"
+        case .swiftPackage: return "Swift Package"
+        case .maven: return "Maven"
+        case .gradleJVM: return "Gradle"
+        case .sbt: return "sbt"
+        case .dotnet: return ".NET"
+        case .composer: return "PHP"
+        case .bundler: return "Ruby"
+        case .haskellStack: return "Haskell (Stack)"
+        case .haskellCabal: return "Haskell (Cabal)"
+        case .zig: return "Zig"
+        case .ocamlDune: return "OCaml"
+        case .cmake: return "CMake"
+        case .terraform: return "Terraform"
+        case .godot: return "Godot"
+        case .unity: return "Unity"
+        case .unreal: return "Unreal"
         }
     }
-
 }
 
 /// High-level grouping of removable folders tied to one project directory.
-nonisolated enum DeletableArtifactKind: String, Hashable, Sendable {
+nonisolated enum DeletableArtifactKind: String, Hashable, Sendable, CaseIterable {
     case nodeModules = "node_modules"
     case venv
     case dotGradle = ".gradle"
     case target
     case pods = "Pods"
     case dartTool = ".dart_tool"
-    case flutterBuild = "Flutter build"
+    case flutterBuild = "flutter-build"
+    case elixirBuild = "_build"
+    case elixirDeps = "deps"
+    case nextBuild = ".next"
+    case nuxtBuild = ".nuxt"
+    case nuxtOutput = ".output"
+    case svelteKitBuild = ".svelte-kit"
+    case astroBuild = ".astro"
+    case angularCache = ".angular"
+    case turboCache = ".turbo"
+    case parcelCache = ".parcel-cache"
+    case viteCache = ".vite"
+    case pytestCache = ".pytest_cache"
+    case mypyCache = ".mypy_cache"
+    case ruffCache = ".ruff_cache"
+    case toxEnvironments = ".tox"
+    case swiftPMBuild = ".build"
+    case mavenTarget = "maven-target"
+    case gradleBuild = "gradle-build"
+    case sbtTarget = "sbt-target"
+    case dotnetBin = "bin"
+    case dotnetObj = "obj"
+    case composerVendor = "vendor"
+    case bundlerVendor = "bundler-vendor"
+    case stackWork = ".stack-work"
+    case cabalDist = "dist-newstyle"
+    case zigCache = "zig-cache"
+    case zigOut = "zig-out"
+    case duneBuild = "dune-build"
+    case cmakeBuild = "cmake-build"
+    case terraformPlugins = ".terraform"
+    case godotCache = ".godot"
+    case unityLibrary = "unity-library"
+    case unityTemp = "unity-temp"
+    case unrealIntermediate = "unreal-intermediate"
+    case unrealDerivedData = "unreal-derived-data"
 
-    /// `explanations.json` lookup key used for headline and explanation.
+    /// `explanations.json` lookup key, and the short label shown under a row.
+    ///
+    /// Held as a table rather than two switch statements so that adding an ecosystem
+    /// means adding data in one place. A kind missing from the table still resolves,
+    /// falling back to its raw value, so a typo degrades to a plain label instead of
+    /// failing to compile or crashing.
+    private static let metadata: [DeletableArtifactKind: (explanationKey: String, rowTag: String)] = [
+        .nodeModules: ("node_modules", "Dependencies"),
+        .venv: ("venv", "Python env"),
+        .dotGradle: ("gradle-cache", "Gradle"),
+        .target: ("target", "Rust build"),
+        .pods: ("Pods", "Pods"),
+        .dartTool: ("dart-tool", "Dart tool cache"),
+        .flutterBuild: ("flutter-cache", "Flutter build"),
+        .elixirBuild: ("elixir-build", "Elixir build"),
+        .elixirDeps: ("elixir-deps", "Elixir deps"),
+        .nextBuild: ("next-build", "Next.js build"),
+        .nuxtBuild: ("nuxt-build", "Nuxt build"),
+        .nuxtOutput: ("nuxt-output", "Nuxt output"),
+        .svelteKitBuild: ("sveltekit-build", "SvelteKit build"),
+        .astroBuild: ("astro-build", "Astro build"),
+        .angularCache: ("angular-cache", "Angular cache"),
+        .turboCache: ("turbo-cache", "Turborepo cache"),
+        .parcelCache: ("parcel-cache", "Parcel cache"),
+        .viteCache: ("vite-cache", "Vite cache"),
+        .pytestCache: ("pytest-cache", "pytest cache"),
+        .mypyCache: ("mypy-cache", "mypy cache"),
+        .ruffCache: ("ruff-cache", "ruff cache"),
+        .toxEnvironments: ("tox-environments", "tox envs"),
+        .swiftPMBuild: ("swiftpm-build", "Swift build"),
+        .mavenTarget: ("maven-target", "Maven build"),
+        .gradleBuild: ("gradle-build", "Gradle build"),
+        .sbtTarget: ("sbt-target", "sbt build"),
+        .dotnetBin: ("dotnet-bin", ".NET build"),
+        .dotnetObj: ("dotnet-obj", ".NET intermediate"),
+        .composerVendor: ("composer-vendor", "PHP packages"),
+        .bundlerVendor: ("bundler-vendor", "Ruby gems"),
+        .stackWork: ("stack-work", "Stack build"),
+        .cabalDist: ("cabal-dist", "Cabal build"),
+        .zigCache: ("zig-cache", "Zig cache"),
+        .zigOut: ("zig-out", "Zig output"),
+        .duneBuild: ("dune-build", "Dune build"),
+        .cmakeBuild: ("cmake-build", "CMake build"),
+        .terraformPlugins: ("terraform-plugins", "Terraform plugins"),
+        .godotCache: ("godot-cache", "Godot cache"),
+        .unityLibrary: ("unity-library", "Unity Library"),
+        .unityTemp: ("unity-temp", "Unity temp"),
+        .unrealIntermediate: ("unreal-intermediate", "Unreal intermediate"),
+        .unrealDerivedData: ("unreal-derived-data", "Unreal cache"),
+    ]
+
     nonisolated var explanationKey: String {
-        switch self {
-        case .nodeModules: return "node_modules"
-        case .venv: return "venv"
-        case .dotGradle: return "gradle-cache"
-        case .target: return "target"
-        case .pods: return "Pods"
-        case .dartTool: return "dart-tool"
-        case .flutterBuild: return "flutter-cache"
-        }
+        Self.metadata[self]?.explanationKey ?? rawValue
     }
 
     nonisolated var rowTag: String {
-        switch self {
-        case .nodeModules: return "Dependencies"
-        case .venv: return "Python env"
-        case .dotGradle: return "Gradle"
-        case .target: return "Rust build"
-        case .pods: return "Pods"
-        case .dartTool: return "Dart tool cache"
-        case .flutterBuild: return "Flutter build"
-        }
+        Self.metadata[self]?.rowTag ?? rawValue
     }
 }
 

--- a/purge/Resources/explanations.json
+++ b/purge/Resources/explanations.json
@@ -2740,5 +2740,435 @@
     "bundle_ids": [],
     "aliases": [],
     "scope": "app_caches"
+  },
+  {
+    "key": "elixir-build",
+    "display_name": "Elixir Build Output",
+    "tag": "safe",
+    "explanation": "Compiled output created by Mix, the build tool for Elixir and Erlang projects. Safe to delete and rebuilt from your own source code the next time you compile.",
+    "bundle_ids": [],
+    "aliases": [
+      "_build",
+      "elixir-build"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "elixir-deps",
+    "display_name": "Elixir Dependencies",
+    "tag": "safe",
+    "explanation": "Dependency source code downloaded by Mix for an Elixir or Erlang project. Safe to delete and re-downloaded on your next build, which needs an internet connection.",
+    "bundle_ids": [],
+    "aliases": [
+      "elixir-deps"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "hex-packages",
+    "display_name": "Hex Package Cache",
+    "tag": "safe",
+    "explanation": "Downloaded Elixir and Erlang packages kept by Hex so repeat builds do not re-download them. Safe to delete and re-downloaded on your next build.",
+    "bundle_ids": [],
+    "aliases": [
+      "Hex Package Cache",
+      ".hex"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "rebar3-cache",
+    "display_name": "Rebar3 Cache",
+    "tag": "safe",
+    "explanation": "Downloaded packages and build plugins kept by Rebar3, the Erlang build tool. Safe to delete and re-downloaded on your next build.",
+    "bundle_ids": [],
+    "aliases": [
+      "Rebar3 Cache",
+      "rebar3"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "next-build",
+    "display_name": "Next.js Build Output",
+    "tag": "safe",
+    "explanation": "Compiled pages and assets produced by Next.js. Safe to delete and rebuilt the next time you run or build the site.",
+    "bundle_ids": [],
+    "aliases": [
+      ".next"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "nuxt-build",
+    "display_name": "Nuxt Build Cache",
+    "tag": "safe",
+    "explanation": "Temporary build files created by Nuxt. Safe to delete and rebuilt the next time you run or build the site.",
+    "bundle_ids": [],
+    "aliases": [
+      ".nuxt"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "nuxt-output",
+    "display_name": "Nuxt Output",
+    "tag": "safe",
+    "explanation": "The built site Nuxt produces for deployment. Safe to delete and rebuilt on your next build.",
+    "bundle_ids": [],
+    "aliases": [
+      ".output"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "sveltekit-build",
+    "display_name": "SvelteKit Build Cache",
+    "tag": "safe",
+    "explanation": "Generated files SvelteKit keeps between builds. Safe to delete and rebuilt the next time you run the project.",
+    "bundle_ids": [],
+    "aliases": [
+      ".svelte-kit"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "astro-build",
+    "display_name": "Astro Build Cache",
+    "tag": "safe",
+    "explanation": "Temporary build files created by Astro. Safe to delete and rebuilt on your next build.",
+    "bundle_ids": [],
+    "aliases": [
+      ".astro"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "angular-cache",
+    "display_name": "Angular Build Cache",
+    "tag": "safe",
+    "explanation": "Build cache kept by the Angular CLI to make repeat builds faster. Safe to delete and rebuilt automatically.",
+    "bundle_ids": [],
+    "aliases": [
+      ".angular"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "pytest-cache",
+    "display_name": "pytest Cache",
+    "tag": "safe",
+    "explanation": "Test results and lookup data cached by pytest. Safe to delete and recreated the next time you run your tests.",
+    "bundle_ids": [],
+    "aliases": [
+      ".pytest_cache"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "tox-environments",
+    "display_name": "tox Environments",
+    "tag": "safe",
+    "explanation": "Throwaway Python environments tox builds to run tests in. Safe to delete and rebuilt on your next tox run, which re-downloads packages.",
+    "bundle_ids": [],
+    "aliases": [
+      ".tox"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "swiftpm-build",
+    "display_name": "Swift Package Build",
+    "tag": "safe",
+    "explanation": "Compiled output from Swift Package Manager. Safe to delete and rebuilt by your next swift build.",
+    "bundle_ids": [],
+    "aliases": [],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "maven-target",
+    "display_name": "Maven Build Output",
+    "tag": "safe",
+    "explanation": "Compiled classes and packaged output produced by Maven. Safe to delete and rebuilt by your next build.",
+    "bundle_ids": [],
+    "aliases": [],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "gradle-build",
+    "display_name": "Gradle Build Output",
+    "tag": "safe",
+    "explanation": "Compiled output produced by a Gradle build. Safe to delete and rebuilt by your next build.",
+    "bundle_ids": [],
+    "aliases": [],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "sbt-target",
+    "display_name": "sbt Build Output",
+    "tag": "safe",
+    "explanation": "Compiled output produced by sbt for a Scala project. Safe to delete and rebuilt by your next build.",
+    "bundle_ids": [],
+    "aliases": [],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "dotnet-bin",
+    "display_name": "NET Build Output",
+    "tag": "safe",
+    "explanation": "Compiled programs and libraries produced by a .NET build. Safe to delete and rebuilt by your next dotnet build.",
+    "bundle_ids": [],
+    "aliases": [],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "dotnet-obj",
+    "display_name": "NET Intermediate Files",
+    "tag": "safe",
+    "explanation": "Temporary files .NET creates while compiling. Safe to delete and recreated on your next build.",
+    "bundle_ids": [],
+    "aliases": [],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "composer-vendor",
+    "display_name": "PHP Packages",
+    "tag": "safe",
+    "explanation": "Third-party PHP packages downloaded by Composer. Safe to delete and re-downloaded by composer install, which needs an internet connection.",
+    "bundle_ids": [],
+    "aliases": [],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "bundler-vendor",
+    "display_name": "Ruby Gems",
+    "tag": "safe",
+    "explanation": "Ruby gems installed into the project by Bundler. Safe to delete and reinstalled by bundle install, which needs an internet connection.",
+    "bundle_ids": [],
+    "aliases": [],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "stack-work",
+    "display_name": "Stack Build Output",
+    "tag": "safe",
+    "explanation": "Compiled output and dependencies kept by Stack for a Haskell project. Safe to delete and rebuilt by your next build, which can take a while.",
+    "bundle_ids": [],
+    "aliases": [
+      ".stack-work"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "cabal-dist",
+    "display_name": "Cabal Build Output",
+    "tag": "safe",
+    "explanation": "Compiled output produced by Cabal for a Haskell project. Safe to delete and rebuilt by your next build, which can take a while.",
+    "bundle_ids": [],
+    "aliases": [
+      "dist-newstyle"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "zig-cache",
+    "display_name": "Zig Build Cache",
+    "tag": "safe",
+    "explanation": "Compilation cache kept by Zig. Safe to delete and rebuilt on your next build.",
+    "bundle_ids": [],
+    "aliases": [
+      ".zig-cache"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "zig-out",
+    "display_name": "Zig Build Output",
+    "tag": "safe",
+    "explanation": "Finished programs and libraries produced by a Zig build. Safe to delete and rebuilt on your next build.",
+    "bundle_ids": [],
+    "aliases": [],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "dune-build",
+    "display_name": "Dune Build Output",
+    "tag": "safe",
+    "explanation": "Compiled output produced by Dune for an OCaml project. Safe to delete and rebuilt by your next build.",
+    "bundle_ids": [],
+    "aliases": [],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "cmake-build",
+    "display_name": "CMake Build Output",
+    "tag": "safe",
+    "explanation": "Compiled output and build configuration produced by CMake. Safe to delete, though you will need to configure and build the project again.",
+    "bundle_ids": [],
+    "aliases": [],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "terraform-plugins",
+    "display_name": "Terraform Plugins",
+    "tag": "safe",
+    "explanation": "Provider plugins and modules Terraform downloads for a workspace. Safe to delete and re-downloaded by terraform init.",
+    "bundle_ids": [],
+    "aliases": [
+      ".terraform"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "godot-cache",
+    "display_name": "Godot Project Cache",
+    "tag": "safe",
+    "explanation": "Imported assets and editor data Godot keeps for a project. Safe to delete and rebuilt the next time you open the project.",
+    "bundle_ids": [],
+    "aliases": [
+      ".godot"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "unity-library",
+    "display_name": "Unity Library Folder",
+    "tag": "medium",
+    "explanation": "Unity's imported-asset database for this project. It rebuilds itself, but reimporting a large project can take a long time, so check before removing it.",
+    "bundle_ids": [],
+    "aliases": [],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "unity-temp",
+    "display_name": "Unity Temp Folder",
+    "tag": "medium",
+    "explanation": "Scratch files Unity writes while the editor is running. Recreated automatically, but do not remove it while the project is open in Unity.",
+    "bundle_ids": [],
+    "aliases": [],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "unreal-intermediate",
+    "display_name": "Unreal Intermediate Files",
+    "tag": "medium",
+    "explanation": "Generated build files Unreal creates while compiling a project. They come back on the next build, which will take longer than usual.",
+    "bundle_ids": [],
+    "aliases": [],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "unreal-derived-data",
+    "display_name": "Unreal Derived Data Cache",
+    "tag": "medium",
+    "explanation": "Cooked assets and compiled shaders Unreal caches for a project. Rebuilt automatically, but the first build afterwards can be very slow.",
+    "bundle_ids": [],
+    "aliases": [],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "nuget-packages",
+    "display_name": "NuGet Package Cache",
+    "tag": "safe",
+    "explanation": "Downloaded .NET packages kept by NuGet so repeat builds do not re-download them. Safe to delete and re-downloaded on your next build.",
+    "bundle_ids": [],
+    "aliases": [
+      "NuGet Packages"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "stack-global",
+    "display_name": "Stack Global Cache",
+    "tag": "medium",
+    "explanation": "Compilers and packages Stack downloads for Haskell projects. Safe to delete, but the next build re-downloads a lot and can be slow.",
+    "bundle_ids": [],
+    "aliases": [
+      "Stack Cache"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "cabal-packages",
+    "display_name": "Cabal Package Cache",
+    "tag": "safe",
+    "explanation": "Haskell packages downloaded by Cabal. Safe to delete and re-downloaded on your next build.",
+    "bundle_ids": [],
+    "aliases": [
+      "Cabal Packages"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "bazel-cache",
+    "display_name": "Bazel Build Cache",
+    "tag": "medium",
+    "explanation": "Build outputs Bazel caches between builds. Safe to delete, though the next build starts from scratch and can be slow.",
+    "bundle_ids": [],
+    "aliases": [
+      "Bazel Cache"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "swiftpm-cache",
+    "display_name": "Swift Package Cache",
+    "tag": "safe",
+    "explanation": "Package checkouts Swift Package Manager shares between projects. Safe to delete and re-downloaded on your next build.",
+    "bundle_ids": [],
+    "aliases": [
+      "Swift Package Cache"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
+  },
+  {
+    "key": "venv",
+    "display_name": "Python Environment",
+    "tag": "safe",
+    "explanation": "A self-contained Python environment holding packages installed for one project. Safe to delete and recreated by reinstalling from requirements.txt or pyproject.toml, which needs an internet connection.",
+    "bundle_ids": [],
+    "aliases": [
+      "venv",
+      ".venv"
+    ],
+    "scope": "dev_tools",
+    "staleness_aware": true
   }
 ]

--- a/purge/Services/DeletionSafetyPolicy.swift
+++ b/purge/Services/DeletionSafetyPolicy.swift
@@ -179,6 +179,7 @@ enum DeletionSafetyPolicy {
     /// nested below them remain reachable through the whitelist.
     nonisolated static func neverDeleteExactPaths(home: String) -> [String] {
         [
+            "\(home)/Library",
             "\(home)/Library/Application Support",
             "\(home)/Documents",
             "\(home)/Desktop",
@@ -236,6 +237,21 @@ enum DeletionSafetyPolicy {
             "\(home)/.zcompdump",
             "\(home)/.cargo/registry",
             "\(home)/.pub-cache",
+            // Hex is Elixir/Erlang's package registry; `packages` is a pure download
+            // cache, re-fetched by `mix deps.get`. `~/.mix` is deliberately NOT listed:
+            // it holds installed Mix archives (tools the user chose to install), not a cache.
+            "\(home)/.hex/packages",
+            "\(home)/.cache/rebar3",
+            "\(home)/.nuget/packages",
+            "\(home)/.bun/install/cache",
+            "\(home)/.cabal/packages",
+            "\(home)/Library/Caches/org.swift.swiftpm",
+            "\(home)/.swiftpm/cache",
+            // AUDIT: `.stack` also holds downloaded GHC compilers, and `~/.cache/bazel`
+            // can be tens of GB. Both re-download rather than being lost, but the next
+            // build is very slow — surfaced as Check First, never Safe.
+            "\(home)/.stack",
+            "\(home)/.cache/bazel",
             "\(home)/.flutter",
             // NOTE: `~/Library/Application Support/MobileSync/Backup` (iPhone/iPad
             // backups) is deliberately NOT on the allowlist. Those backups are
@@ -295,14 +311,25 @@ enum DeletionSafetyPolicy {
 
     /// Whether Purge may offer this path for manual or scheduled cleanup (no admin prompt).
     ///
-    /// Memoised by path. The verdict is a pure function of the path and the static
-    /// allowlists — nothing here reads size, mtime, or user state — so a repeat lookup
-    /// can only produce the same answer. This matters because `filterCacheItems` runs
-    /// over the *entire* accumulated result set on every scan flush, so without a cache
-    /// the policy was re-evaluated (items x flushes) times on the main thread; profiling
-    /// a scan put essentially the whole per-flush cost inside this one call.
+    /// Memoised by path, because `filterCacheItems` runs over the *entire* accumulated
+    /// result set on every scan flush; without a cache the policy was re-evaluated
+    /// (items x flushes) times on the main thread, which profiling showed to be
+    /// essentially the whole per-flush cost.
+    ///
+    /// What may be cached is narrower than it looks. `evaluate` now reads the disk, to
+    /// check whether a project marker sits above a generically-named folder. That is
+    /// safe to memoise: a `mix.exs` or `composer.json` identifies a project for as long
+    /// as the project exists, so the answer cannot flip mid-session.
+    ///
+    /// Refusals are the exception and are deliberately kept *outside* the cache. Whether
+    /// a `.terraform` folder holds state changes the moment someone runs `terraform
+    /// apply`, so a verdict cached before that would keep offering a folder that has
+    /// since become dangerous. It is re-checked on every call, and only for the handful
+    /// of folder names that declare a refusal at all.
     nonisolated static func isOfferedForCleanup(_ url: URL) -> Bool {
         let key = url.standardizedFileURL.path
+
+        if projectArtifactRefusesDeletion(url) { return false }
 
         offeredForCleanupLock.lock()
         let cached = offeredForCleanupCache[key]
@@ -564,6 +591,53 @@ enum DeletionSafetyPolicy {
         return true
     }
 
+    /// Whether this path is a build artifact of a real project sitting right above it.
+    ///
+    /// This is the mechanism that lets Purge offer folders whose *names* are far too
+    /// generic to ever allow globally — `bin`, `obj`, `vendor`, `Temp`, and Unity's
+    /// `Library`. Nothing is allowed on the strength of its name. The folder only
+    /// qualifies when the directory it sits in is demonstrably a project of the matching
+    /// kind, proven by a marker file such as `mix.exs`, `composer.json`, or a `.csproj`.
+    ///
+    /// Deliberately evaluated *after* the never-delete guards in `evaluate`, so a project
+    /// checked out inside Pictures, Music, or Mail still exposes nothing.
+    /// Whether any rule matching this folder name refuses it because of what is inside.
+    ///
+    /// Intentionally not memoised: unlike a project marker, the contents this looks for
+    /// can appear between one scan and the next.
+    nonisolated static func projectArtifactRefusesDeletion(_ url: URL) -> Bool {
+        let standardized = url.standardizedFileURL
+        guard let candidates = ProjectArtifactCatalog.rulesByFolderName[standardized.lastPathComponent] else {
+            return false
+        }
+        return candidates.contains { $0.refusesArtifact(at: standardized) }
+    }
+
+    nonisolated static func isWhitelistedProjectArtifactPath(_ url: URL, home: String) -> Bool {
+        let standardized = url.standardizedFileURL
+        let path = standardized.path
+        guard path == home || path.hasPrefix(home + "/") else { return false }
+
+        guard let candidates = ProjectArtifactCatalog.rulesByFolderName[standardized.lastPathComponent] else {
+            return false
+        }
+
+        for rule in candidates {
+            // Walk back up by however many components the rule's folder spans, so
+            // `ios/Pods` anchors on the Xcode project root rather than on `ios`.
+            let depth = rule.folder.split(separator: "/").count
+            var root = standardized
+            for _ in 0..<depth { root = root.deletingLastPathComponent() }
+            guard root.path.hasPrefix(home + "/") || root.path == home else { continue }
+            guard rule.matchesRoot(root) else { continue }
+            // Checked here rather than only in the scanner so that no caller can route
+            // around it: a `.terraform` folder holding state is never deletable.
+            guard !rule.refusesArtifact(at: standardized) else { continue }
+            return true
+        }
+        return false
+    }
+
     nonisolated static func evaluate(_ url: URL) -> DeletionSafetyDecision {
         let standardized = url.standardizedFileURL
         let path = standardized.path
@@ -609,6 +683,12 @@ enum DeletionSafetyPolicy {
 
         let inHome = path == home || path.hasPrefix(home + "/")
         if inHome && whitelistedFolderNames.contains(standardized.lastPathComponent) {
+            return .allow
+        }
+        // Deliberately below the never-delete guards, exactly like the folder-name rule
+        // above it: this matches on a name plus nearby evidence, not on an audited
+        // absolute path, so the protections for Pictures, Music, Mail and the rest win.
+        if isWhitelistedProjectArtifactPath(standardized, home: home) {
             return .allow
         }
 

--- a/purge/Services/DevScanner.swift
+++ b/purge/Services/DevScanner.swift
@@ -414,6 +414,21 @@ nonisolated final class DevScanner {
             ("Yarn Cache", [home.appendingPathComponent("Library/Caches/Yarn", isDirectory: true)]),
             ("Gradle Cache", [home.appendingPathComponent(".gradle/caches", isDirectory: true)]),
             ("Flutter Cache", [home.appendingPathComponent(".flutter", isDirectory: true)]),
+            ("Hex Package Cache", [home.appendingPathComponent(".hex/packages", isDirectory: true)]),
+            ("Rebar3 Cache", [home.appendingPathComponent(".cache/rebar3", isDirectory: true)]),
+            ("NuGet Packages", [home.appendingPathComponent(".nuget/packages", isDirectory: true)]),
+            // `~/.deno` deliberately not listed: `deno upgrade` and `deno install` put the
+            // deno binary and script shims in `~/.deno/bin`, so offering it would offer
+            // the toolchain itself. DENO_DIR (the real cache) lives under Library/Caches.
+            ("Deno Cache", [home.appendingPathComponent("Library/Caches/deno", isDirectory: true)]),
+            ("Bun Cache", [home.appendingPathComponent(".bun/install/cache", isDirectory: true)]),
+            ("Cabal Packages", [home.appendingPathComponent(".cabal/packages", isDirectory: true)]),
+            ("Stack Cache", [home.appendingPathComponent(".stack", isDirectory: true)]),
+            ("Bazel Cache", [home.appendingPathComponent(".cache/bazel", isDirectory: true)]),
+            ("Swift Package Cache", [
+                home.appendingPathComponent("Library/Caches/org.swift.swiftpm", isDirectory: true),
+                home.appendingPathComponent(".swiftpm/cache", isDirectory: true)
+            ]),
             ("Android SDK .gradle", [home.appendingPathComponent(".android", isDirectory: true)]),
             ("Docker Desktop", [home.appendingPathComponent("Library/Containers/com.docker.docker", isDirectory: true)]),
 
@@ -766,16 +781,12 @@ nonisolated final class DevScanner {
         var directoriesWalked = 0
 
         func shouldSkipDescending(into name: String) -> Bool {
+            // Never walk *into* a folder that is itself a removable artifact, or into
+            // heavy vendor/VCS folders. Derived from the catalog so a new ecosystem
+            // cannot accidentally leave the walker descending into its own build output.
+            if ProjectArtifactCatalog.artifactFolderNames.contains(name) { return true }
             switch name {
-            case ".git", "node_modules", "Pods", "DerivedData", ".gradle":
-                return true
-            case ".dart_tool":
-                return true
-            case "venv", ".venv":
-                return true
-            case "target":
-                return true
-            case "build":
+            case ".git", "DerivedData":
                 return true
             case "android", "ios":
                 return true
@@ -784,33 +795,58 @@ nonisolated final class DevScanner {
             }
         }
 
+        /// Markers that identify a project type by plain file existence. Types needing
+        /// more than a filename check (Xcode bundles, Gradle's nested `android/`
+        /// folder, extension globs) are handled separately below.
         func listTypes(at directory: URL) -> [ProjectType] {
             var result: Set<ProjectType> = []
 
-            let packageJSON = directory.appendingPathComponent("package.json").path
-            if fm.fileExists(atPath: packageJSON) {
-                result.insert(.node)
+            func anyExists(_ names: [String]) -> Bool {
+                names.contains { fm.fileExists(atPath: directory.appendingPathComponent($0).path) }
             }
 
-            if fm.fileExists(atPath: directory.appendingPathComponent("Cargo.toml").path) {
-                result.insert(.rust)
-            }
-
-            if fm.fileExists(atPath: directory.appendingPathComponent("pubspec.yaml").path) {
-                result.insert(.flutter)
-            }
-
-            if fm.fileExists(atPath: directory.appendingPathComponent("requirements.txt").path)
-                || fm.fileExists(atPath: directory.appendingPathComponent("pyproject.toml").path) {
-                result.insert(.python)
+            let simpleMarkers: [(ProjectType, [String])] = [
+                (.node, ["package.json"]),
+                (.rust, ["Cargo.toml"]),
+                (.flutter, ["pubspec.yaml"]),
+                (.python, ["requirements.txt", "pyproject.toml", "tox.ini"]),
+                (.elixir, ["mix.exs"]),
+                (.swiftPackage, ["Package.swift"]),
+                (.maven, ["pom.xml"]),
+                (.sbt, ["build.sbt"]),
+                (.composer, ["composer.json"]),
+                (.bundler, ["Gemfile"]),
+                (.haskellStack, ["stack.yaml"]),
+                (.zig, ["build.zig"]),
+                (.ocamlDune, ["dune-project"]),
+                (.cmake, ["CMakeLists.txt"]),
+                (.godot, ["project.godot"]),
+                (.unity, ["ProjectSettings/ProjectVersion.txt"]),
+            ]
+            for (type, markers) in simpleMarkers where anyExists(markers) {
+                result.insert(type)
             }
 
             if hasGradleMarker(in: directory) {
+                // Every Gradle project has a `.gradle` folder, which this type owns.
                 result.insert(.androidGradle)
+                // `.gradleJVM` additionally offers the root `build/` folder and suggests
+                // `./gradlew build`. Android projects are excluded: their build output is
+                // per-module rather than at the root, and the row would duplicate the
+                // Gradle entry above under a label and command that do not fit.
+                let isAndroid = anyExists(["android/build.gradle", "android/build.gradle.kts"])
+                    || fm.fileExists(atPath: directory.appendingPathComponent("app/src/main/AndroidManifest.xml").path)
+                if !isAndroid, anyExists(["build.gradle", "build.gradle.kts"]) {
+                    result.insert(.gradleJVM)
+                }
             }
 
             if containsXcodeBundle(in: directory) {
                 result.insert(.xcode)
+            }
+
+            for type in extensionMarkedTypes(in: directory) {
+                result.insert(type)
             }
 
             return Array(result).sorted { String(describing: $0) < String(describing: $1) }
@@ -890,6 +926,35 @@ nonisolated final class DevScanner {
             detail: "\(artifactsSized) artifacts sized, \(groups.count) project groups"
         )
         return groups
+    }
+
+    /// Project types identified by a file *extension* rather than an exact name.
+    /// One directory listing serves all of them, since listing is the expensive part.
+    private func extensionMarkedTypes(in directory: URL) -> [ProjectType] {
+        guard let children = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
+        ) else {
+            return []
+        }
+
+        var found: Set<ProjectType> = []
+        for child in children {
+            switch child.pathExtension.lowercased() {
+            case "csproj", "fsproj", "vbproj", "sln":
+                found.insert(.dotnet)
+            case "cabal":
+                found.insert(.haskellCabal)
+            case "tf":
+                found.insert(.terraform)
+            case "uproject":
+                found.insert(.unreal)
+            default:
+                continue
+            }
+        }
+        return Array(found)
     }
 
     private func containsXcodeBundle(in directory: URL) -> Bool {
@@ -1020,7 +1085,7 @@ nonisolated final class DevScanner {
         )
     }
 
-    private struct SizedArtifactIntermediate {
+    struct SizedArtifactIntermediate {
         let kind: DeletableArtifactKind
         let path: URL
         let projectRoot: URL
@@ -1028,11 +1093,12 @@ nonisolated final class DevScanner {
         let reinstallSafety: ReinstallSafetyStatus
     }
 
-    private nonisolated static func collectArtifacts(projectRoot root: URL, types: [ProjectType]) -> [SizedArtifactIntermediate] {
+    nonisolated static func collectArtifacts(projectRoot root: URL, types: [ProjectType]) -> [SizedArtifactIntermediate] {
         let fm = FileManager.default
         var artifacts: [SizedArtifactIntermediate] = []
+        let detected = Set(types)
 
-        func addIfDir(kind: DeletableArtifactKind, url: URL) {
+        func addIfDir(rule: ProjectArtifactRule, url: URL) {
             guard fm.fileExists(atPath: url.path) else { return }
             guard DeletionSafetyPolicy.isOfferedForCleanup(url) else { return }
             // Also drops every artifact under an excluded project root, since the store
@@ -1044,16 +1110,17 @@ nonisolated final class DevScanner {
             }
             guard isDir else { return }
 
-            let reinstall = Self.reinstallCommand(kind: kind, root: root)
+            let reinstall = Self.reinstallCommand(rule: rule, root: root)
             let safety = SafetyInfo.forStaleProjectArtifact(
-                kind: kind,
+                kind: rule.kind,
                 path: url,
-                reinstallCommand: reinstall
+                reinstallCommand: reinstall,
+                level: rule.level
             )
-            let reinstallStatus = ReinstallSafetyEvaluator.evaluate(artifactKind: kind, artifactURL: url)
+            let reinstallStatus = ReinstallSafetyEvaluator.evaluate(artifactKind: rule.kind, artifactURL: url)
             artifacts.append(
                 SizedArtifactIntermediate(
-                    kind: kind,
+                    kind: rule.kind,
                     path: url,
                     projectRoot: root,
                     safetyInfo: safety,
@@ -1062,51 +1129,14 @@ nonisolated final class DevScanner {
             )
         }
 
-        var hasNode = false
-        var hasRust = false
-        var hasFlutter = false
-        var hasPython = false
-        var hasAndroidGradle = false
-        var hasXcode = false
-        for t in types {
-            switch t {
-            case .node: hasNode = true
-            case .rust: hasRust = true
-            case .flutter: hasFlutter = true
-            case .python: hasPython = true
-            case .androidGradle: hasAndroidGradle = true
-            case .xcode: hasXcode = true
-            }
-        }
-
-        if hasNode,
-           fm.fileExists(atPath: root.appendingPathComponent("package.json").path) {
-            addIfDir(kind: .nodeModules, url: root.appendingPathComponent("node_modules", isDirectory: true))
-        }
-
-        if hasRust,
-           fm.fileExists(atPath: root.appendingPathComponent("Cargo.toml").path) {
-            addIfDir(kind: .target, url: root.appendingPathComponent("target", isDirectory: true))
-        }
-
-        if hasFlutter,
-           fm.fileExists(atPath: root.appendingPathComponent("pubspec.yaml").path) {
-            addIfDir(kind: .dartTool, url: root.appendingPathComponent(".dart_tool", isDirectory: true))
-            addIfDir(kind: .flutterBuild, url: root.appendingPathComponent("build", isDirectory: true))
-        }
-
-        if hasPython {
-            addIfDir(kind: .venv, url: root.appendingPathComponent("venv", isDirectory: true))
-            addIfDir(kind: .venv, url: root.appendingPathComponent(".venv", isDirectory: true))
-        }
-
-        if hasAndroidGradle {
-            addIfDir(kind: .dotGradle, url: root.appendingPathComponent(".gradle", isDirectory: true))
-        }
-
-        if hasXcode {
-            addIfDir(kind: .pods, url: root.appendingPathComponent("Pods", isDirectory: true))
-            addIfDir(kind: .pods, url: root.appendingPathComponent("ios").appendingPathComponent("Pods", isDirectory: true))
+        for rule in ProjectArtifactCatalog.rules where detected.contains(rule.projectType) {
+            // The rule's own anchor is re-checked even though `listTypes` already matched
+            // the project type, because one type can cover several markers: a Python
+            // project with `requirements.txt` but no `tox.ini` must not offer `.tox`.
+            guard rule.matchesRoot(root) else { continue }
+            let artifact = root.appendingPathComponent(rule.folder, isDirectory: true)
+            guard !rule.refusesArtifact(at: artifact) else { continue }
+            addIfDir(rule: rule, url: artifact)
         }
 
         var unique: [String: SizedArtifactIntermediate] = [:]
@@ -1116,25 +1146,23 @@ nonisolated final class DevScanner {
         return Array(unique.values)
     }
 
-    private nonisolated static func reinstallCommand(kind: DeletableArtifactKind, root: URL) -> String? {
-        switch kind {
-        case .nodeModules:
+    private nonisolated static func reinstallCommand(rule: ProjectArtifactRule, root: URL) -> String? {
+        switch rule.reinstall {
+        case .command(let template):
+            return template.replacingOccurrences(of: "{root}", with: root.path)
+        case .guidance(let text):
+            return text
+        case .nodePackageManager:
             let pm = NodePackageManager.detect(in: root)
             return "cd \"\(root.path)\" && \(pm.installCommand)"
-        case .target:
-            return "cd \"\(root.path)\" && cargo build"
-        case .venv:
-            return "Use your usual steps to recreate the Python environment for this folder."
-        case .dotGradle:
-            return "Run your usual project build so Android or Java tools fetch what they need again."
-        case .pods:
+        case .cocoaPods:
             let ios = root.appendingPathComponent("ios", isDirectory: true)
             if FileManager.default.fileExists(atPath: ios.appendingPathComponent("Podfile").path) {
                 return "cd \"\(ios.path)\" && pod install"
             }
             return "cd \"\(root.path)\" && pod install"
-        case .dartTool, .flutterBuild:
-            return "cd \"\(root.path)\" && flutter pub get"
+        case .none:
+            return nil
         }
     }
 }

--- a/purge/Services/ReinstallSafetyEvaluator.swift
+++ b/purge/Services/ReinstallSafetyEvaluator.swift
@@ -1,76 +1,63 @@
 import Foundation
 
 enum ReinstallSafetyEvaluator {
-    nonisolated private static func hasFile(_ dir: URL, _ name: String) -> Bool {
-        FileManager.default.fileExists(atPath: dir.appendingPathComponent(name).path)
+    nonisolated private static func exists(_ dir: URL, _ relative: String) -> Bool {
+        let url = dir.appendingPathComponent(relative).standardizedFileURL
+        return FileManager.default.fileExists(atPath: url.path)
     }
 
-    /// Parent folder relative to artifact (for `something/node_modules` parent is project root).
+    /// Whether a removed artifact can be brought back cleanly.
+    ///
+    /// Both checks are resolved against the artifact's own parent directory, which is
+    /// the project root for a top-level folder like `node_modules` and a subdirectory
+    /// for a nested one like `ios/Pods`. Rules use `..` where the evidence lives a
+    /// level up (sbt's `project/target`, Bundler's `vendor/bundle`).
     nonisolated static func evaluate(artifactKind: DeletableArtifactKind, artifactURL: URL) -> ReinstallSafetyStatus {
-        switch artifactKind {
-        case .nodeModules:
-            let parent = artifactURL.deletingLastPathComponent()
-            guard hasFile(parent, "package.json") else { return .missingLockfile }
-            let hasLock = hasFile(parent, "package-lock.json")
-                || hasFile(parent, "npm-shrinkwrap.json")
-                || hasFile(parent, "yarn.lock")
-                || hasFile(parent, "pnpm-lock.yaml")
-            return hasLock ? .reinstallable : .missingLockfile
-
-        case .venv:
-            let parent = artifactURL.deletingLastPathComponent()
-            let ok = hasFile(parent, "requirements.txt") || hasFile(parent, "pyproject.toml")
-            return ok ? .reinstallable : .missingLockfile
-
-        case .target:
-            let parent = artifactURL.deletingLastPathComponent()
-            return hasFile(parent, "Cargo.toml") ? .reinstallable : .missingLockfile
-
-        case .dotGradle:
-            let parent = artifactURL.deletingLastPathComponent()
-            let ok = gradleEvidenceExists(in: parent)
-            return ok ? .reinstallable : .missingLockfile
-
-        case .pods:
-            let podsParent = artifactURL.deletingLastPathComponent()
-            return hasFile(podsParent, "Podfile.lock") ? .reinstallable : .missingLockfile
-
-        case .dartTool, .flutterBuild:
-            let parent = artifactURL.deletingLastPathComponent()
-            guard hasFile(parent, "pubspec.yaml") else { return .missingLockfile }
-            return hasFile(parent, "pubspec.lock") ? .reinstallable : .missingLockfile
-        }
+        status(for: ProjectArtifactCatalog.rules(forKind: artifactKind), artifactURL: artifactURL)
     }
 
-    nonisolated private static func gradleEvidenceExists(in projectRoot: URL) -> Bool {
-        if hasFile(projectRoot, "build.gradle") || hasFile(projectRoot, "build.gradle.kts")
-            || hasFile(projectRoot, "settings.gradle") || hasFile(projectRoot, "settings.gradle.kts") {
-            return true
-        }
-        let android = projectRoot.appendingPathComponent("android", isDirectory: true)
-        return hasFile(android, "build.gradle") || hasFile(android, "build.gradle.kts")
-    }
-
+    /// Used when a folder is being deleted without a scan row behind it, so the only
+    /// thing known about it is its name.
+    ///
+    /// Every rule sharing that folder name is considered, not just the first one found.
+    /// `target` belongs to Rust, Maven and sbt, and `_build` to both Elixir and Dune;
+    /// picking one arbitrarily would report "no lockfile" for a perfectly rebuildable
+    /// project simply because a different ecosystem happened to be listed first.
     nonisolated static func evaluateByFolderNameDeleting(path: URL) -> ReinstallSafetyStatus {
         let name = path.lastPathComponent.lowercased()
-        switch name {
-        case "node_modules":
-            return evaluate(artifactKind: .nodeModules, artifactURL: path)
-        case "venv", ".venv":
-            let parent = path.deletingLastPathComponent()
-            return hasFile(parent, "requirements.txt") || hasFile(parent, "pyproject.toml")
-                ? .reinstallable : .missingLockfile
-        case ".gradle":
-            let parent = path.deletingLastPathComponent()
-            return gradleEvidenceExists(in: parent) ? .reinstallable : .missingLockfile
-        case "target":
-            return evaluate(artifactKind: .target, artifactURL: path)
-        case "pods":
-            return evaluate(artifactKind: .pods, artifactURL: path)
-        case "deriveddata":
-            return .notApplicable
-        default:
-            return .notApplicable
+        let matching = ProjectArtifactCatalog.rules.filter {
+            URL(fileURLWithPath: $0.folder).lastPathComponent.lowercased() == name
         }
+        return status(for: matching, artifactURL: path)
+    }
+
+    /// A kind can carry several rules (Python's `venv` and `.venv`, Zig's two cache
+    /// folder names). Any single rule finding complete evidence is enough.
+    ///
+    /// Rules that require no evidence at all are skipped rather than returned on, so
+    /// the verdict does not depend on the order rules happen to sit in the catalog.
+    /// Only when *no* rule asked for evidence does this report `.notApplicable`.
+    nonisolated private static func status(
+        for rules: [ProjectArtifactRule],
+        artifactURL: URL
+    ) -> ReinstallSafetyStatus {
+        guard !rules.isEmpty else { return .notApplicable }
+        let parent = artifactURL.deletingLastPathComponent()
+        var anyRuleWantedEvidence = false
+
+        for rule in rules {
+            guard !rule.rebuildMarkers.isEmpty || !rule.lockfiles.isEmpty else { continue }
+            anyRuleWantedEvidence = true
+
+            if !rule.rebuildMarkers.isEmpty {
+                guard rule.rebuildMarkers.contains(where: { exists(parent, $0) }) else { continue }
+            }
+            if !rule.lockfiles.isEmpty {
+                guard rule.lockfiles.contains(where: { exists(parent, $0) }) else { continue }
+            }
+            return .reinstallable
+        }
+
+        return anyRuleWantedEvidence ? .missingLockfile : .notApplicable
     }
 }

--- a/purge/Views/DevModeView.swift
+++ b/purge/Views/DevModeView.swift
@@ -240,7 +240,42 @@ struct DevToolsView<PageHeader: View>: View {
         true
     }
 
+    /// Resolves a group by identity rather than by position.
+    ///
+    /// The row helpers below are read from closures that SwiftUI re-invokes on its own
+    /// schedule — `ScanSelectionScope` exists precisely so a selection change re-renders
+    /// the checkbox without rebuilding the whole list. A rescan replaces `projectGroups`
+    /// wholesale, so a position captured when the row was first built can point past the
+    /// end of the new array by the time such a closure runs. Identity survives that;
+    /// a position does not.
+    private func projectGroupIndex(forID id: String) -> Int? {
+        store.projectGroups.firstIndex { $0.id == id }
+    }
+
+    private func eligibleArtifactIndices(forGroupID id: String) -> [Int] {
+        guard let gi = projectGroupIndex(forID: id) else { return [] }
+        return eligibleArtifactIndices(forGroupIndex: gi)
+    }
+
+    private func projectSelectTriState(forGroupID id: String) -> SelectAllTriState {
+        guard let gi = projectGroupIndex(forID: id) else { return .none }
+        return projectSelectTriState(forGroupIndex: gi)
+    }
+
+    private func toggleProjectEligibleSelection(groupID id: String) {
+        guard let gi = projectGroupIndex(forID: id) else { return }
+        toggleProjectEligibleSelection(groupIndex: gi)
+    }
+
+    private func visibleGroupByteTotal(groupID id: String) -> Int64 {
+        guard let gi = projectGroupIndex(forID: id) else { return 0 }
+        return visibleGroupByteTotal(groupIndex: gi)
+    }
+
     private func eligibleArtifactIndices(forGroupIndex gi: Int) -> [Int] {
+        // Defence in depth: the id-addressed entry points above are the supported route,
+        // but a stale index must degrade to an empty result rather than trap.
+        guard store.projectGroups.indices.contains(gi) else { return [] }
         let g = store.projectGroups[gi]
         return g.artifacts.indices.filter { ai in
             let art = g.artifacts[ai]
@@ -251,7 +286,7 @@ struct DevToolsView<PageHeader: View>: View {
 
     private func projectSelectTriState(forGroupIndex gi: Int) -> SelectAllTriState {
         let eligible = eligibleArtifactIndices(forGroupIndex: gi)
-        guard !eligible.isEmpty else { return .none }
+        guard !eligible.isEmpty, store.projectGroups.indices.contains(gi) else { return .none }
 
         let g = store.projectGroups[gi]
         let selectedIDs = store.scanSelection.artifactIDs
@@ -263,9 +298,10 @@ struct DevToolsView<PageHeader: View>: View {
 
     private func toggleProjectEligibleSelection(groupIndex gi: Int) {
         let eligible = eligibleArtifactIndices(forGroupIndex: gi)
-        guard !eligible.isEmpty else { return }
+        guard !eligible.isEmpty, store.projectGroups.indices.contains(gi) else { return }
+        let group = store.projectGroups[gi]
         let selectedIDs = store.scanSelection.artifactIDs
-        let allOn = eligible.allSatisfy { selectedIDs.contains(store.projectGroups[gi].artifacts[$0].id) }
+        let allOn = eligible.allSatisfy { selectedIDs.contains(group.artifacts[$0].id) }
         let newVal = !allOn
         for ai in eligible {
             store.setProjectArtifactSelected(groupIndex: gi, artifactIndex: ai, isSelected: newVal)
@@ -273,12 +309,15 @@ struct DevToolsView<PageHeader: View>: View {
     }
 
     private func visibleGroupByteTotal(groupIndex gi: Int) -> Int64 {
-        sortedVisibleArtifactIndices(forGroup: gi).reduce(Int64(0)) { sum, ai in
-            sum + store.projectGroups[gi].artifacts[ai].sizeBytes
+        guard store.projectGroups.indices.contains(gi) else { return 0 }
+        let group = store.projectGroups[gi]
+        return sortedVisibleArtifactIndices(forGroup: gi).reduce(Int64(0)) { sum, ai in
+            sum + group.artifacts[ai].sizeBytes
         }
     }
 
     private func sortedVisibleArtifactIndices(forGroup gi: Int) -> [Int] {
+        guard store.projectGroups.indices.contains(gi) else { return [] }
         let g = store.projectGroups[gi]
         let raw = g.artifacts.indices.filter {
             artifactVisible(g.artifacts[$0].safetyInfo)
@@ -892,8 +931,8 @@ struct DevToolsView<PageHeader: View>: View {
                 // Scoped so the group tri-state reflects artifact selection changes
                 // without re-rendering the list container.
                 ScanSelectionScope(selection: store.scanSelection, isSelected: { _ in false }) { _ in
-                    TriStateCheckbox(title: "", state: projectSelectTriState(forGroupIndex: currentGroupIndex)) {
-                        toggleProjectEligibleSelection(groupIndex: currentGroupIndex)
+                    TriStateCheckbox(title: "", state: projectSelectTriState(forGroupID: group.id)) {
+                        toggleProjectEligibleSelection(groupID: group.id)
                     }
                 }
                 .frame(width: 24)
@@ -911,7 +950,7 @@ struct DevToolsView<PageHeader: View>: View {
                         Text(group.displayName)
                             .font(AppStyle.Typography.rowTitle)
                             .frame(maxWidth: .infinity, alignment: .leading)
-                        Text(formatBytes(visibleGroupByteTotal(groupIndex: currentGroupIndex)))
+                        Text(formatBytes(visibleGroupByteTotal(groupID: group.id)))
                             .font(AppStyle.Typography.rowTitle)
                             .foregroundStyle(.secondary)
                             .monospacedDigit()


### PR DESCRIPTION
## What does this change?

Purge could only find leftover build files for six kinds of projects: Node, Rust, Flutter, Xcode, Python and Android. If you worked in anything else, your project junk was invisible to it, and the only fix was to file an issue and wait.

This adds seventeen more. Elixir and Erlang, Swift Packages, Maven, Gradle, sbt, .NET, PHP, Ruby, both Haskell toolchains, Zig, OCaml, CMake, Terraform, Godot, Unity and Unreal. It also picks up the framework folders that Next.js, Nuxt, SvelteKit, Astro and Angular leave behind, and the caches pytest, mypy, ruff and tox keep, none of which were ever offered before. Eight shared caches come along too: NuGet, Deno, Bun, Cabal, Stack, Bazel, Hex and Swift Package Manager.

For most people this simply means the Dev Tools tab finds more, and the numbers get bigger.

### On safety

Most of these folders have dangerously ordinary names. `bin`, `obj`, `vendor`, `Temp`, and in Unity's case `Library`. Purge used to decide what it could delete partly by folder name, and that approach does not survive names like these. Allowing a folder called `Library` would have put your entire `~/Library` at risk.

So nothing here is allowed because of what it is called. A folder only becomes deletable when the directory it sits in is provably a project of the right kind, proven by a real marker file next to it. PHP's `vendor` folder needs a `composer.json` beside it. Unity's `Library` needs Unity's own project file. Everything else named `vendor` or `Library` stays untouched, and there's a test asserting no rule in the whole set can ever match on name alone.

Three things are deliberately offered as **Check First** rather than **Safe to Clean**, which means Purge shows them to you but never removes them on its own, and never during a scheduled clean:

- **Unity and Unreal.** These rebuild themselves, but reimporting a large game project can take half an hour and it starts the moment you next open the editor. Reclaiming 30 GB is great. Losing an afternoon to a surprise reimport is not.
- **Terraform.** Its `.terraform` folder is mostly downloadable plugins, but it is also where your infrastructure state can live. Any folder actually holding state is now refused outright rather than offered at all.

Three things are deliberately *not* included, so we have a written answer next time someone asks. Go's `vendor` folder is often committed to git on purpose, so deleting it deletes tracked source. Hugo's `public` folder is generated output in Hugo and hand-written source almost everywhere else. Bazel's in-project entries are only shortcuts, so removing them frees nothing; the real cache is covered as a shared cache instead.

### Also fixed

A crash when you scanned twice in a row. The project group checkbox remembered a row's position in the list, and rescanning rebuilds that list, so the remembered position could point at nothing. It now identifies rows by which project they are rather than where they sat. The bug predates this branch, but adding more projects made it happen almost every time, which is how it surfaced.

Python environments also had no description attached, so they had been showing a vague fallback message. They now explain themselves properly.

## Related issue

Refs #33. Deliberately does not close it: see the note below.

This delivers what the person who filed it actually needed, since Elixir is now supported directly, and heads off the same request for most other ecosystems. But the thing they asked for was the ability to define their own patterns, and that is still to come. The rules here live in a single declarative catalog, which is the same shape a user-defined rule will take, so this is the groundwork for that rather than a detour around it.


## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I built and ran the app locally
- [x] I ran the test suite (`xcodebuild ... test`) and it passes (406 tests)
- [x] This PR is focused on a single fix/feature


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cleanup detection for more ecosystems, including Elixir, JavaScript frameworks, Python tools, JVM, .NET, Ruby, Haskell, game engines, and infrastructure tools.
  - Added project-aware artifact rules with tailored safety levels and reinstall guidance.
  - Added explanations for newly supported cleanup items.

- **Bug Fixes**
  - Improved deletion safeguards for protected locations and risky project state.
  - Improved cleanup results when projects are rescanned or selections change.

- **Tests**
  - Expanded coverage for artifact detection, deletion safety, reinstall requirements, and catalog integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->