### PR TITLE
fix: add Development project scan roots

### DIFF
--- a/purge/Services/DevScanner.swift
+++ b/purge/Services/DevScanner.swift
@@ -746,6 +746,9 @@ nonisolated final class DevScanner {
         let roots = [
             home,
             home.appendingPathComponent("Developer", isDirectory: true),
+            home.appendingPathComponent("developer", isDirectory: true),
+            home.appendingPathComponent("Development", isDirectory: true),
+            home.appendingPathComponent("development", isDirectory: true),
             home.appendingPathComponent("Documents", isDirectory: true),
             home.appendingPathComponent("Desktop", isDirectory: true),
             home.appendingPathComponent("Downloads", isDirectory: true),


### PR DESCRIPTION
## What does this change?

Adds `~/Development` & `~/development` to the default developer project scan roots so projects stored under those directories can be discovered.
Also adds lowercase `~/developer` for consistency with the existing case variants such as `Projects/projects` and `Code/code`.

No other scanning behavior is changed.

## Related issue

None

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I built and ran the app locally
- [x] I ran the test suite (`xcodebuild ... test`) and it passes
- [x] This PR is focused on a single fix/feature


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project discovery by scanning additional common home-directory folders, including `developer`, `Development`, and `development`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->