### PR TITLE
Duplicates: count removable copies and declutter the group header (#36)

### DIFF
--- a/PurgeTests/DuplicateFileDetectorTests.swift
+++ b/PurgeTests/DuplicateFileDetectorTests.swift
@@ -290,6 +290,8 @@ struct DuplicateFileDetectorTests {
 
         let section = try? #require(sections.first)
         #expect(section?.displayedCopyCount == 2)
+        // Removable copies exclude the one keeper, matching the reclaimable bytes.
+        #expect(section?.displayedReclaimableCount == 1)
         #expect(section?.displayedReclaimableBytes == 1_000)
         // The index still believes there are three.
         #expect(section?.group.copyCount == 3)

--- a/purge/Models/LargeFile.swift
+++ b/purge/Models/LargeFile.swift
@@ -203,6 +203,13 @@ nonisolated enum LargeFileCategoryFilter {
         /// before the index is pruned.
         var displayedCopyCount: Int { memberIndices.count }
 
+        /// How many copies here are *removable* — every rendered copy but the one
+        /// worth keeping. This is what the Duplicates chip counts: counting all
+        /// copies would include the keeper and overstate the redundancy, the same
+        /// way `group.reclaimableBytes` excludes one copy from the space it
+        /// promises. Derived from the rendered rows so it can never exceed them.
+        var displayedReclaimableCount: Int { max(displayedCopyCount - 1, 0) }
+
         /// Space freed by keeping one of the rendered copies. Ordering the list
         /// reads this rather than `group.reclaimableBytes` for the same reason:
         /// groups must sort by the number the header shows.

--- a/purge/Views/LargeFilesView.swift
+++ b/purge/Views/LargeFilesView.swift
@@ -848,27 +848,26 @@ private struct DuplicateGroupCard: View {
                 .strokeBorder(AppColors.borderSubtle, lineWidth: 1)
         }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(
-            "\(section.displayedCopyCount) identical copies, \(formatBytes(section.group.sizeBytes)) each"
-        )
+        .accessibilityLabel("\(section.displayedCopyCount) identical copies")
     }
 
     private var header: some View {
         HStack(spacing: 6) {
+            // Same colour as the title beside it: this marks the card as a group,
+            // it isn't a warning, so it shouldn't pull the eye the way the yellow
+            // check tint did.
             Image(systemName: "square.on.square")
                 .imageScale(.small)
-                .foregroundStyle(AppColors.tagCheckText)
+                .foregroundStyle(AppColors.textSecondary)
                 .accessibilityHidden(true)
 
-            Text("\(section.displayedCopyCount) identical copies · \(formatBytes(section.group.sizeBytes)) each")
+            // No size here. Every copy is the same size and each row already shows
+            // it, so a "9.4 MB each" and a "free 9.4 MB" on the header just repeated
+            // the one number the rows carry — three sizes for a two-copy set.
+            Text("\(section.displayedCopyCount) identical copies")
                 .foregroundStyle(AppColors.textSecondary)
 
-            Spacer(minLength: 8)
-
-            // States the prize without naming a winner: which copy to keep is the
-            // user's call, so this never says "delete the one in Downloads".
-            Text("Keep one to free \(formatBytes(section.displayedReclaimableBytes))")
-                .foregroundStyle(AppColors.textTertiary)
+            Spacer(minLength: 0)
         }
         .font(AppStyle.Typography.metadataEmphasis)
         .lineLimit(1)

--- a/purge/Views/LargeFilesView.swift
+++ b/purge/Views/LargeFilesView.swift
@@ -265,11 +265,16 @@ struct LargeFilesView: View {
                             id: Self.duplicatesFilterID,
                             title: "Duplicates",
                             systemImage: "square.on.square",
+                            // The count of *removable* copies — one keeper per
+                            // group excluded — so it answers "what here is
+                            // redundant?" and agrees with the reclaimable bytes
+                            // rather than double-counting the copy worth keeping.
+                            //
                             // Counted from the sections the list would draw, not
                             // from the query matches: a query matching one copy
                             // expands to its whole group, so counting matches
                             // directly would advertise fewer rows than appear.
-                            count: duplicateSections.reduce(0) { $0 + $1.displayedCopyCount },
+                            count: duplicateSections.reduce(0) { $0 + $1.displayedReclaimableCount },
                             tier: .checkFirst
                         )
                     }


### PR DESCRIPTION
## What does this change?

Two Duplicates-view fixes.

**1. Chip counts removable copies.** The chip counted *every* copy in every group, so 10 sets of two identical files reported **20** — even though only **10** files are actually removable (one copy per group is worth keeping). It now counts removable copies (`Σ (copyCount − 1)`) via a new `Section.displayedReclaimableCount`, agreeing with `DuplicateGroup.reclaimableBytes`. No secondary/group count is added — the number stays inside the chip only.

**2. Declutter the group header.** The header repeated the copy size the rows already show — "N identical copies · **9.4 MB each**" on the left and "Keep one to free **9.4 MB**" on the right — so a two-copy set quoted the same size three times. Both are removed; the header now reads just "**N identical copies**", and the per-item rows remain the single place a size appears. The group glyph is also recolored from the yellow check tint to the header's own secondary text color — it marks a set, it isn't a warning.

## Related issue

Fixes #36. The "keep one, delete the rest" action is split out to #39.

## Screenshots

Header before: `⧉ 2 identical copies · 9.4 MB each … Keep one to free 9.4 MB` (yellow icon)
Header after: `⧉ 2 identical copies` (grey icon) — size shown once, on each row.

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I built and ran the app locally
- [x] I ran the test suite (`xcodebuild ... test`) and it passes
- [x] This PR is focused on a single fix/feature
