### PR TITLE
feat: keep one of each duplicate, delete the rest (#39)

### DIFF
--- a/PurgeTests/DuplicateKeeperTests.swift
+++ b/PurgeTests/DuplicateKeeperTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import Purge
+
+/// Covers the keeper the "keep one, delete the rest" flow suggests. It only
+/// suggests — the user can override — so the bar is "reasonable and stable", not
+/// "provably right". These pin the ordering so the suggestion doesn't drift.
+@Suite("Duplicate keeper suggestion")
+struct DuplicateKeeperTests {
+    private func file(_ path: String, lastUsed: Date = Date()) -> LargeFile {
+        LargeFile(
+            path: URL(fileURLWithPath: path),
+            sizeBytes: 9_400_000,
+            lastUsed: lastUsed,
+            category: .other
+        )
+    }
+
+    private func suggested(_ paths: [String]) -> String? {
+        DuplicateKeeper.suggestedKeeperID(among: paths.map { file($0) })
+    }
+
+    @Test
+    func keepsTheRealHomeOverADownload() {
+        let keeper = suggested([
+            "/Users/x/Downloads/snapshot.sqlite",
+            "/Users/x/Documents/grocery/App/Resources/snapshot.sqlite",
+        ])
+        #expect(keeper == "/Users/x/Documents/grocery/App/Resources/snapshot.sqlite")
+    }
+
+    @Test
+    func keepsTheRealHomeOverABuildArtifact() {
+        let keeper = suggested([
+            "/Users/x/Documents/grocery/App/Resources/snapshot.sqlite",
+            "/Users/x/Documents/grocery/DerivedData/Build/snapshot.sqlite",
+            "/Users/x/Documents/grocery/App/node_modules/pkg/snapshot.sqlite",
+        ])
+        #expect(keeper == "/Users/x/Documents/grocery/App/Resources/snapshot.sqlite")
+    }
+
+    @Test
+    func prefersADownloadOverACache() {
+        let keeper = suggested([
+            "/Users/x/Library/Caches/app/snapshot.sqlite",
+            "/Users/x/Downloads/snapshot.sqlite",
+        ])
+        #expect(keeper == "/Users/x/Downloads/snapshot.sqlite")
+    }
+
+    @Test
+    func keepsTheCanonicalNameOverACopy() {
+        let keeper = suggested([
+            "/Users/x/Documents/snapshot copy.sqlite",
+            "/Users/x/Documents/snapshot.sqlite",
+            "/Users/x/Documents/snapshot copy 2.sqlite",
+        ])
+        #expect(keeper == "/Users/x/Documents/snapshot.sqlite")
+    }
+
+    @Test
+    func treatsParenthesizedNumberAsACopy() {
+        let keeper = suggested([
+            "/Users/x/Documents/report (1).pdf",
+            "/Users/x/Documents/report.pdf",
+        ])
+        #expect(keeper == "/Users/x/Documents/report.pdf")
+    }
+
+    /// Nothing separates two same-location, same-kind names but the path, so the
+    /// pick has to be stable rather than order-dependent.
+    @Test
+    func breaksTiesDeterministically() {
+        let paths = [
+            "/Users/x/Documents/b/snapshot.sqlite",
+            "/Users/x/Documents/a/snapshot.sqlite",
+        ]
+        #expect(suggested(paths) == "/Users/x/Documents/a/snapshot.sqlite")
+        #expect(suggested(paths.reversed()) == "/Users/x/Documents/a/snapshot.sqlite")
+    }
+
+    @Test
+    func emptyGroupHasNoKeeper() {
+        #expect(DuplicateKeeper.suggestedKeeperID(among: []) == nil)
+    }
+}

--- a/purge/ContentView.swift
+++ b/purge/ContentView.swift
@@ -86,6 +86,13 @@ struct ContentView: View {
                 onConfirm: { Task { await store.confirmLargeFileDeletion() } }
             )
         }
+        .sheet(item: $store.pendingDuplicateCleanup) { request in
+            DuplicateCleanupSheet(
+                request: request,
+                onCancel: { store.dismissDuplicateCleanup() },
+                onConfirm: { keepers in Task { await store.confirmDuplicateCleanup(keeperByGroupID: keepers) } }
+            )
+        }
         .disabled(store.isManualCleaningInProgress)
         .overlay {
             if isLifecycleActive, let session = store.interactiveSafeCleanupSession {

--- a/purge/Models/DuplicateKeeper.swift
+++ b/purge/Models/DuplicateKeeper.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Suggests which copy in a duplicate group is worth keeping, so the "keep one,
+/// delete the rest" action can pre-select a survivor.
+///
+/// This only *suggests*. The user always sees the choice and can pick a different
+/// copy before anything moves to Trash. Issue #17 rejected choosing the survivor
+/// *silently*; a visible, overridable suggestion is a different thing.
+///
+/// The pick is deterministic and based only on the path, because that is all a
+/// duplicate group agrees on. Every copy is byte-identical and the same size, so
+/// content tells them apart in no way. Signals, most important first:
+///
+/// 1. **Where it lives.** A copy in a cache, a build folder, or `node_modules` is
+///    disposable; one in Downloads or on the Desktop is a landing zone; anything
+///    else is treated as a real home. Keep the realest home.
+/// 2. **What it's called.** A `… copy`, `… copy 2`, or `… (1)` name is the copy,
+///    not the original. Keep the canonical name.
+/// 3. **Tie-breakers.** Fewer path components, then the path itself, so the same
+///    group always suggests the same keeper across scans.
+nonisolated enum DuplicateKeeper {
+    /// The id of the copy to keep, or nil for an empty group.
+    static func suggestedKeeperID(among files: [LargeFile]) -> String? {
+        files.min { sortKey(for: $0) < sortKey(for: $1) }?.id
+    }
+
+    /// Lower sorts first, and first is the keeper.
+    private static func sortKey(for file: LargeFile) -> (Int, Int, Int, String) {
+        let path = file.id // already the standardized path
+        let base = file.path.deletingPathExtension().lastPathComponent
+        return (
+            locationRank(path),
+            copyNameRank(base),
+            path.split(separator: "/").count,
+            path
+        )
+    }
+
+    /// 0 for a real home, 1 for a landing zone (Downloads/Desktop), 2 for a
+    /// disposable location. The keeper wants the lowest.
+    private static func locationRank(_ path: String) -> Int {
+        let lower = path.lowercased()
+        let disposable = [
+            "/library/caches/", "/caches/", "/.cache/",
+            "/deriveddata/", "/library/developer/xcode/",
+            "/node_modules/", "/.build/", "/build/", "/target/",
+            "/.trash/", "/tmp/", "/.tmp/",
+        ]
+        if disposable.contains(where: lower.contains) { return 2 }
+        if lower.contains("/downloads/") || lower.contains("/desktop/") { return 1 }
+        return 0
+    }
+
+    /// 1 when the name looks like a duplicate the OS or the user made — `foo copy`,
+    /// `foo copy 3`, `foo (1)` — else 0. The keeper wants 0.
+    private static func copyNameRank(_ base: String) -> Int {
+        let name = base.lowercased()
+        if name.range(of: #" copy( \d+)?$"#, options: .regularExpression) != nil { return 1 }
+        if name.range(of: #" \(\d+\)$"#, options: .regularExpression) != nil { return 1 }
+        return 0
+    }
+}

--- a/purge/Services/PurgeStore.swift
+++ b/purge/Services/PurgeStore.swift
@@ -57,6 +57,22 @@ final class LargeFileDuplicateIndex: ObservableObject {
     }
 }
 
+/// One duplicate set in the cleanup review: its copies and the keeper suggested
+/// for them. `id` is the group id, so the sheet can key its per-set keeper choice.
+nonisolated struct DuplicateCopySet: Identifiable {
+    let id: String
+    let copies: [LargeFile]
+    let suggestedKeeperID: String
+}
+
+/// A pending "keep one of each, delete the rest" review across every duplicate
+/// set. `id` is derived from the sets so `.sheet(item:)` doesn't re-present the
+/// same review, but changes when the sets do (a scan or an earlier delete).
+nonisolated struct DuplicateCleanupRequest: Identifiable {
+    let sets: [DuplicateCopySet]
+    var id: String { sets.map(\.id).joined(separator: "|") }
+}
+
 /// Scan-tab selection (app caches, dev tools, simulators, project artifacts) kept in
 /// its own observable, held as a plain `let` on the store (NOT @Published), so a
 /// toggle re-renders only the views that display selection — never the results List
@@ -199,6 +215,9 @@ final class PurgeStore: ObservableObject {
     let scanSelection = ScanSelection()
     @Published var isScanningLargeFiles = false
     @Published var showLargeFileDeletionSheet = false
+    /// The duplicate-cleanup review awaiting confirmation, or nil when closed.
+    /// Drives a `.sheet(item:)`.
+    @Published var pendingDuplicateCleanup: DuplicateCleanupRequest?
     /// Best-effort git status keyed by standardized tool path (`URL.path`).
     @Published private(set) var devToolRepoStatusByPath: [String: GitWorktreeStatus] = [:] {
         didSet { invalidateSafeCleanupSummary() }
@@ -1055,9 +1074,50 @@ final class PurgeStore: ObservableObject {
         showLargeFileDeletionSheet = false
     }
 
+    /// Opens the duplicate-cleanup review: one keeper suggested per set, every
+    /// other copy bound for Trash. Nothing deletes here — the review names the rule
+    /// and shows the kept copy against the trashed ones, and the keeper is
+    /// changeable, so the app never removes a copy the user hasn't seen and agreed
+    /// to (issue #17).
+    func requestDuplicateCleanup() {
+        let index = largeFileDuplicates.index
+        guard !index.isEmpty else { return }
+        let byID = Dictionary(largeFiles.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        let sets: [DuplicateCopySet] = index.groups.compactMap { group in
+            let copies = group.fileIDs.compactMap { byID[$0] }
+            guard copies.count > 1 else { return nil }
+            let keeper = DuplicateKeeper.suggestedKeeperID(among: copies) ?? copies[0].id
+            return DuplicateCopySet(id: group.id, copies: copies, suggestedKeeperID: keeper)
+        }
+        guard !sets.isEmpty else { return }
+        pendingDuplicateCleanup = DuplicateCleanupRequest(sets: sets)
+    }
+
+    func dismissDuplicateCleanup() {
+        pendingDuplicateCleanup = nil
+    }
+
+    /// Trashes every copy except the chosen keeper in each set. `keeperByGroupID`
+    /// carries the user's final pick per set (defaulting to the suggestion). Runs
+    /// through the same delete path as the selection flow, so it gets the same
+    /// Trash safety, progress overlay, and history entry.
+    func confirmDuplicateCleanup(keeperByGroupID: [String: String]) async {
+        guard let request = pendingDuplicateCleanup else { return }
+        pendingDuplicateCleanup = nil
+        var targets: [LargeFile] = []
+        for copySet in request.sets {
+            let keeper = keeperByGroupID[copySet.id] ?? copySet.suggestedKeeperID
+            targets.append(contentsOf: copySet.copies.filter { $0.id != keeper })
+        }
+        await performLargeFileDeletion(targets: targets)
+    }
+
     func confirmLargeFileDeletion() async {
         showLargeFileDeletionSheet = false
-        let targets = selectedLargeFiles
+        await performLargeFileDeletion(targets: selectedLargeFiles)
+    }
+
+    private func performLargeFileDeletion(targets: [LargeFile]) async {
         guard !targets.isEmpty, !isDeleting else { return }
 
         // A row can stand for several files (an AI model is a manifest plus its

--- a/purge/Theme/AppColors.swift
+++ b/purge/Theme/AppColors.swift
@@ -35,6 +35,9 @@ enum AppColors {
     static let tagCheckBg = Color(light: .hex(0xFBEED8), dark: .hex(0x332910))
     static let tagDangerText = Color(light: .hex(0xC5392E), dark: .hex(0xF2685C))
     static let tagDangerBg = Color(light: .hex(0xFBE6E3), dark: .hex(0x321B19))
+    /// Bright, saturated red for a solid destructive button fill (white text on
+    /// top). The muted `tagDangerText` reads salmon-pale as a fill on dark.
+    static let destructiveFill = Color(light: .hex(0xE5322A), dark: .hex(0xFF3B30))
     static let tagUnsureText = Color(light: .hex(0x5C5E66), dark: .hex(0xA7A9B2))
     static let tagUnsureBg = Color(light: .hex(0xEDEDEF), dark: .hex(0x26272D))
 

--- a/purge/Views/LargeFilesView.swift
+++ b/purge/Views/LargeFilesView.swift
@@ -394,7 +394,10 @@ struct LargeFilesView: View {
             selection: store.largeFileSelection,
             visibleIDs: visibleIDs,
             sort: sortOptionBinding,
-            onToggleAll: toggleSelectAll
+            onToggleAll: toggleSelectAll,
+            onKeepOneOfEach: isDuplicatesFilterActive
+                ? { store.requestDuplicateCleanup() }
+                : nil
         )
     }
 
@@ -668,6 +671,9 @@ private struct LargeFileSelectAllBar: View {
     let visibleIDs: [String]
     @Binding var sort: SortOption
     let onToggleAll: () -> Void
+    /// Shown only under the Duplicates filter: selects every copy but one per group
+    /// and opens the delete confirmation. nil elsewhere.
+    var onKeepOneOfEach: (() -> Void)?
 
     private var state: SelectAllTriState {
         guard !visibleIDs.isEmpty else { return .none }
@@ -686,6 +692,22 @@ private struct LargeFileSelectAllBar: View {
             .disabled(visibleIDs.isEmpty)
 
             Spacer()
+
+            if let onKeepOneOfEach {
+                // Sits with the sort control, not beside "Select All": both are
+                // AppButtonStyle boxes, so grouping them keeps the boxed controls on
+                // one baseline instead of one box riding proud of the plain-text
+                // checkbox. A real Button is fine here — the bar is above the List,
+                // not inside it, so it can't trigger the scroll-to-clicked-row jump
+                // the rows guard against.
+                Button(action: onKeepOneOfEach) {
+                    Label("Delete extra copies", systemImage: "trash")
+                        .labelStyle(.titleAndIcon)
+                }
+                .buttonStyle(AppButtonStyle(variant: .bordered))
+                .fixedSize()
+                .help("Keep one copy of each set and review the rest before deleting")
+            }
 
             // Always present, even under Duplicates where it reorders whole groups
             // rather than rows. Its absence would shrink this bar, and the scan-tab
@@ -1291,6 +1313,196 @@ struct LargeFileDeletionConfirmSheet: View {
                 .fill(AppColors.tagCheckBg)
         )
         .accessibilityElement(children: .combine)
+    }
+}
+
+/// The dialog's primary button: a solid red fill with white text, the standard
+/// destructive treatment. Metrics track `AppButtonStyle(.bordered)` so it and
+/// Cancel keep one height.
+private struct SolidDestructiveButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: AppStyle.Radius.control, style: .continuous)
+                    .fill(AppColors.destructiveFill)
+            )
+            .opacity(isEnabled ? (configuration.isPressed ? 0.72 : 1) : 0.45)
+    }
+}
+
+/// Reviews a "keep one of each, delete the rest" before anything moves.
+///
+/// This is where the selection method is visible: it names the rule up top and,
+/// per set, marks the copy being kept against the ones going to Trash. The keeper
+/// is a tap away from changing, so a user who disagrees with the suggestion moves
+/// it here rather than cancelling and hunting through the list.
+struct DuplicateCleanupSheet: View {
+    let request: DuplicateCleanupRequest
+    let onCancel: () -> Void
+    let onConfirm: ([String: String]) -> Void
+
+    @State private var keeperByGroup: [String: String]
+
+    init(
+        request: DuplicateCleanupRequest,
+        onCancel: @escaping () -> Void,
+        onConfirm: @escaping ([String: String]) -> Void
+    ) {
+        self.request = request
+        self.onCancel = onCancel
+        self.onConfirm = onConfirm
+        _keeperByGroup = State(
+            initialValue: Dictionary(
+                uniqueKeysWithValues: request.sets.map { ($0.id, $0.suggestedKeeperID) }
+            )
+        )
+    }
+
+    private func keeperID(for set: DuplicateCopySet) -> String {
+        keeperByGroup[set.id] ?? set.suggestedKeeperID
+    }
+
+    /// One copy per set is kept, the rest go, so this never changes as keepers move.
+    private var deleteCount: Int {
+        request.sets.reduce(0) { $0 + $1.copies.count - 1 }
+    }
+
+    private var reclaimedBytes: Int64 {
+        request.sets.reduce(Int64(0)) { total, set in
+            let keeper = keeperID(for: set)
+            return total + set.copies.filter { $0.id != keeper }.reduce(Int64(0)) { $0 + $1.sizeBytes }
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppStyle.Spacing.medium) {
+            VStack(alignment: .leading, spacing: AppStyle.Spacing.xSmall) {
+                Text("Delete extra copies")
+                    .font(AppStyle.Typography.pageTitle)
+                    .foregroundStyle(AppColors.textPrimary)
+
+                Text("Every copy is identical, so keeping any one is safe. Purge keeps the copy in a real folder over one in Downloads, a cache, or a build folder, and prefers the original name. The rest go to Trash. Tap a copy to keep it instead.")
+                    .font(.callout)
+                    .foregroundStyle(AppColors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            ScrollView {
+                LazyVStack(spacing: AppStyle.Spacing.small) {
+                    ForEach(request.sets) { set in
+                        setCard(set)
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+            .frame(minHeight: 280)
+
+            HStack(spacing: AppStyle.Spacing.small) {
+                Text("Keeping \(request.sets.count), freeing \(formatBytes(reclaimedBytes))")
+                    .font(AppStyle.Typography.metadataEmphasis)
+                    .foregroundStyle(AppColors.textSecondary)
+
+                Spacer()
+
+                Button("Cancel", action: onCancel)
+                    .buttonStyle(AppButtonStyle(variant: .bordered))
+                    .keyboardShortcut(.cancelAction)
+
+                Button("Move \(deleteCount) to Trash") {
+                    onConfirm(keeperByGroup)
+                }
+                .buttonStyle(SolidDestructiveButtonStyle())
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(AppStyle.Spacing.large)
+        .frame(minWidth: 580, minHeight: 500)
+        .background(AppColors.bgBase)
+    }
+
+    /// One duplicate set as a card, matching the duplicate rows on the tab: a
+    /// header naming the file and its size, then a row per copy.
+    private func setCard(_ set: DuplicateCopySet) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: AppStyle.Spacing.xSmall) {
+                Text(set.copies.first?.displayName ?? "Duplicate set")
+                    .font(AppStyle.Typography.rowTitle)
+                    .foregroundStyle(AppColors.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: AppStyle.Spacing.xSmall)
+                Text("\(formatBytes(set.copies.first?.sizeBytes ?? 0)) each")
+                    .font(AppStyle.Typography.metadata)
+                    .foregroundStyle(AppColors.textSecondary)
+            }
+            .padding(.horizontal, AppStyle.Spacing.small)
+            .padding(.vertical, AppStyle.Spacing.xSmall + 2)
+
+            ForEach(Array(set.copies.enumerated()), id: \.element.id) { index, file in
+                if index > 0 {
+                    Rectangle()
+                        .fill(AppColors.borderSubtle)
+                        .frame(height: 0.5)
+                }
+                copyRow(set: set, file: file)
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: AppStyle.Radius.card, style: .continuous)
+                .fill(AppColors.bgCard)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: AppStyle.Radius.card, style: .continuous)
+                .strokeBorder(AppColors.borderSubtle, lineWidth: 1)
+        )
+    }
+
+    private func copyRow(set: DuplicateCopySet, file: LargeFile) -> some View {
+        let isKeeper = keeperID(for: set) == file.id
+        // Copies in a set share a name, so the folder is what tells them apart.
+        return HStack(spacing: AppStyle.Spacing.small) {
+            Image(systemName: isKeeper ? "largecircle.fill.circle" : "circle")
+                .foregroundStyle(isKeeper ? AppColors.buttonPrimaryBg : AppColors.textTertiary)
+                .accessibilityHidden(true)
+
+            Text(file.path.deletingLastPathComponent().path)
+                .font(AppStyle.Typography.metadata)
+                .foregroundStyle(isKeeper ? AppColors.textPrimary : AppColors.textSecondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Spacer(minLength: AppStyle.Spacing.xSmall)
+
+            statusTag(isKeeper: isKeeper)
+        }
+        .padding(.horizontal, AppStyle.Spacing.small)
+        .padding(.vertical, AppStyle.Spacing.xSmall + 2)
+        .contentShape(Rectangle())
+        .onTapGesture { keeperByGroup[set.id] = file.id }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(file.path.deletingLastPathComponent().path)
+        .accessibilityValue(isKeeper ? "Keeping" : "Moving to Trash")
+        .accessibilityAddTraits(isKeeper ? [.isSelected] : [])
+    }
+
+    /// Reuses the app's tag palette: green for the copy that stays, red for the
+    /// ones headed to Trash, so the plan reads at a glance.
+    private func statusTag(isKeeper: Bool) -> some View {
+        Text(isKeeper ? "Keep" : "Trash")
+            .font(AppStyle.Typography.metadataEmphasis)
+            .foregroundStyle(isKeeper ? AppColors.tagSafeText : AppColors.tagDangerText)
+            .padding(.horizontal, AppStyle.Spacing.xSmall)
+            .padding(.vertical, 2)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(isKeeper ? AppColors.tagSafeBg : AppColors.tagDangerBg)
+            )
     }
 }
 


### PR DESCRIPTION
## What does this change?

Adds a single "Delete extra copies" button to the Duplicates view. It opens a review that keeps one copy per set and moves the rest to Trash, so clearing a whole tab of duplicates is one action instead of hunting through the list and selecting copies by hand.

**The review makes the selection method visible.** Every copy in a set is byte-identical, so the keeper is chosen from the path alone (`DuplicateKeeper`): keep the copy in a real folder over one in Downloads, a cache, or a build folder, then the original filename over a `… copy`, then a stable path tie-break. The dialog names that rule up top and, per set, marks the copy being kept against the ones headed to Trash, using the app's green/red tag palette. The keeper is a tap away from changing, so nothing deletes that the user hasn't seen and agreed to (issue #17).

Deletions run through the same pipeline as the selection flow, so they get the same Trash safety, progress overlay, and history entry.

## Design

The review dialog uses the app's own tokens and components: `AppColors`, `AppStyle` spacing/radii, card surfaces matching the duplicate rows on the tab, and `AppButtonStyle`. The primary button is a solid bright-red destructive fill (new `AppColors.destructiveFill`, since the muted danger tint read salmon-pale as a fill on dark). The bar button pairs a `trash` icon with its label like the sort control beside it.

## Related issue

Fixes #39

## Screenshots

<img width="732" height="370" alt="image" src="https://github.com/user-attachments/assets/69f5b2b3-4ab8-4823-9b98-ebb4a9dea218" />
<img width="621" height="585" alt="image" src="https://github.com/user-attachments/assets/60b390c0-d363-4380-b1b3-59b9d6802b0b" />


## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I built and ran the app locally
- [x] I ran the test suite (`xcodebuild ... test`) and it passes
- [x] This PR is focused on a single fix/feature


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a duplicate cleanup flow to the Large Files tab.
  * Review duplicate groups, choose which copy to keep, and delete remaining copies.
  * Added smart suggestions that prioritize project files and canonical filenames.
  * Added light and dark theme support for destructive actions.
* **Bug Fixes**
  * Duplicate keeper suggestions now remain deterministic regardless of file order.
* **Tests**
  * Added coverage for duplicate prioritization, tie-breaking, copy naming, and empty groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->